### PR TITLE
Add script to use android app id as package name

### DIFF
--- a/docs/deployment/android.md
+++ b/docs/deployment/android.md
@@ -21,6 +21,12 @@ Check that the APPLICATION_ID in `app/build.gradle` is correct.
 
 Ensure that your google-services.json file in /packages/mobile/android/app/ is correct and is registered with the correct APPLICATION_ID
 
+When you have changed the APPLICATION_ID, run this command to update other android configuration files with this id
+
+```bash
+yarn update-android-app-id
+```
+
 Check the values in `/packages/mobile/.env.production` file are correct.
 
 Add to `packages/mobile/android/local.properties`:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -69,6 +69,12 @@ You will need to enter your application id / bundle id. The values of these ids 
 - APPLICATION_ID for android: `/packages/mobile/android/gradle.properties`
 - PRODUCT_BUNDLE_IDENTIFIER for iOS: `/packages/mobile/ios/release.xcconfig`
 
+When you have changed the APPLICATION_ID, run this command to update other android configuration files with this id
+
+```bash
+yarn update-android-app-id
+```
+
 You will need to have 2 apps via the [firebase console](https://console.firebase.google.com/), within your new project. An iOS app and Android app, for the react native app. Download the config files for each app and place them in the correct location, the steps can be found [here](https://learn.buildfire.com/en/articles/2060582-how-to-set-up-your-firebase-certificates-for-ios-and-android).
 
 For the CMS, go to:

--- a/docs/setup_details.md
+++ b/docs/setup_details.md
@@ -35,3 +35,9 @@ To change the bundle ID (iOS) of your app, please change it directly in the untr
 Do not change the bundle ID in Xcode because that will affect the `project.pbxproj` file. This way everyone can be using different bundle IDs without needing to commit changes to `project.pbxproj` on separate branches.
 
 To change the android application ID, please the APPLICATION_ID variable directly in the untracked `gradle.properties` file
+
+When you have changed the APPLICATION_ID, run this command to update other android configuration files with this id
+
+```bash
+yarn update-android-app-id
+```

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "run:android": "yarn clean:mobile && yarn workspace @oky/mobile run android",
     "clean:mobile": "yarn workspace @oky/mobile run clean:android",
     "modules": "./bin/modules/remove.sh && ./bin/modules/pull.sh && yarn copy-assets",
-    "copy-config": "./bin/setup/config.sh"
+    "copy-config": "./bin/setup/config.sh",
+    "update-android-app-id": "ts-node update-android-app-id.ts"
   },
   "workspaces": {
     "packages": [

--- a/packages/mobile/.gitignore
+++ b/packages/mobile/.gitignore
@@ -66,6 +66,12 @@ buck-out/
 ios/GoogleService-Info.plist
 android/app/google-services.json
 
+# Android application Id files
+android/app/BUCK
+android/app/src/main/AndroidManifest.xml
+android/app/src/main/java/*
+android/app/src/debug/java/*
+
 # Bundle Id files
 ios/release.xcconfig
 ios/debug.xcconfig

--- a/packages/mobile/android/app/BUCK.dist
+++ b/packages/mobile/android/app/BUCK.dist
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.oky",
+    package = "{APPLICATION_ID}",
 )
 
 android_resource(
     name = "res",
-    package = "com.oky",
+    package = "{APPLICATION_ID}",
     res = "src/main/res",
 )
 

--- a/packages/mobile/android/app/src/main/AndroidManifest.xml.dist
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml.dist
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.oky">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="{APPLICATION_ID}">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/packages/mobile/android/app/templates/MainActivity.java.dist
+++ b/packages/mobile/android/app/templates/MainActivity.java.dist
@@ -1,4 +1,4 @@
-package com.oky;
+package {APPLICATION_ID};
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;

--- a/packages/mobile/android/app/templates/MainApplication.java.dist
+++ b/packages/mobile/android/app/templates/MainApplication.java.dist
@@ -1,4 +1,4 @@
-package com.oky;
+package {APPLICATION_ID};
 
 import android.app.Application;
 import android.content.Context;
@@ -75,7 +75,7 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.oky.ReactNativeFilpper");
+        Class<?> aClass = Class.forName("{APPLICATION_ID}.ReactNativeFilpper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);

--- a/packages/mobile/android/app/templates/ReactNativeFilpper.java.dist
+++ b/packages/mobile/android/app/templates/ReactNativeFilpper.java.dist
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.oky;
+package {APPLICATION_ID};
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;
 import com.facebook.flipper.android.utils.FlipperUtils;

--- a/update-android-app-id.ts
+++ b/update-android-app-id.ts
@@ -1,0 +1,80 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { logger } from './logger'
+
+const placeholder = '{APPLICATION_ID}'
+
+const templates = [
+  'packages/mobile/android/app/BUCK.dist',
+  'packages/mobile/android/app/src/main/AndroidManifest.xml.dist',
+  'packages/mobile/android/app/templates/MainActivity.java.dist',
+  'packages/mobile/android/app/templates/MainApplication.java.dist',
+  'packages/mobile/android/app/templates/ReactNativeFilpper.java.dist',
+]
+
+const destinations = [
+  'packages/mobile/android/app/BUCK',
+  'packages/mobile/android/app/src/main/AndroidManifest.xml',
+  'packages/mobile/android/app/src/main/java/{APPLICATION_PATH}/MainActivity.java',
+  'packages/mobile/android/app/src/main/java/{APPLICATION_PATH}/MainApplication.java',
+  'packages/mobile/android/app/src/debug/java/{APPLICATION_PATH}/ReactNativeFilpper.java',
+]
+
+const foldersToClean = [
+  'packages/mobile/android/app/src/debug/java',
+  'packages/mobile/android/app/src/main/java',
+]
+
+const gradlePropertiesPath = path.join(__dirname, 'packages/mobile/android/gradle.properties')
+const gradleProperties = fs.readFileSync(gradlePropertiesPath, 'utf8')
+
+const applicationIdMatch = gradleProperties.match(/^APPLICATION_ID=(.+)$/m)
+const applicationId = applicationIdMatch ? applicationIdMatch[1] : null
+
+if (!applicationId) {
+  console.error('APPLICATION_ID not found in gradle.properties')
+  process.exit(1)
+}
+
+const APPLICATION_PATH = applicationId.split('.').join('/')
+
+const updateFiles = async () => {
+  const deleteFolderRecursive = async (filePath) => {
+    try {
+      await fs.promises.rm(filePath, { recursive: true, force: true })
+    } catch (error) {
+      console.error(`Error removing the directory: ${filePath}`, error)
+    }
+  }
+
+  const createFoldersRecursive = async (filePath) => {
+    try {
+      // The recursive option will create all necessary parent directories
+      await fs.promises.mkdir(`${filePath}/${APPLICATION_PATH}`, { recursive: true })
+    } catch (error) {
+      console.error(`Error creating the directory: ${filePath}`, error)
+    }
+  }
+
+  for (const filePath of foldersToClean) {
+    await deleteFolderRecursive(filePath)
+  }
+
+  for (const filePath of foldersToClean) {
+    await createFoldersRecursive(filePath)
+  }
+
+  templates.forEach((template, index) => {
+    const fileContent = fs.readFileSync(template, 'utf8')
+    const updatedContent = fileContent.replaceAll(placeholder, applicationId)
+    const destination = destinations[index].replace('{APPLICATION_PATH}', APPLICATION_PATH)
+    // fs.mkdir()
+    fs.writeFileSync(destination, updatedContent)
+  })
+
+  logger(`============================================================`)
+  logger(`Updated android config with Application ID: ${applicationId}`)
+  logger(`============================================================`)
+}
+
+updateFiles()


### PR DESCRIPTION
Having an editable application Id but constant package name was creating problems sending http requests, preventing accounts being created 