### PR TITLE
fix: Add moduleNameMapper in jest to fix async-storage issue

### DIFF
--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -27,5 +27,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {
     '@expo/vector-icons': '<rootDir>/__mocks__/vector-icons.js',
+    '@react-native-async-storage/async-storage':
+      '@react-native-async-storage/async-storage/jest/async-storage-mock',
   },
 }


### PR DESCRIPTION
Running command:

```

yarn test:app
```

would fail due to an issue with async storage

Adding moduleNameMapper in jest config solves the issue