### PR TITLE
fix: adjust button positions for safe area

### DIFF
--- a/app/src/components/Modal.tsx
+++ b/app/src/components/Modal.tsx
@@ -8,7 +8,7 @@ import {
   ViewStyle,
 } from 'react-native'
 import { FontAwesome } from '@expo/vector-icons'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useScreenDimensions } from '../hooks/useScreenDimensions'
 import { useAccessibilityLabel } from '../hooks/useAccessibilityLabel'
 import { Button, ButtonProps } from './Button'
@@ -60,9 +60,14 @@ export const Modal = ({ visible, toggleVisible, children, style, onDismiss }: Mo
 export const ModalCloseButton = (props: ButtonProps) => {
   const getAccessibilityLabel = useAccessibilityLabel()
   const label = getAccessibilityLabel('close')
+  const insets = useSafeAreaInsets()
 
   return (
-    <Button style={styles.closeButton} status={'basic'} {...props}>
+    <Button
+      style={[styles.closeButton, { top: insets.top + 12 }]}
+      status={'basic'}
+      {...props}
+    >
       <FontAwesome name="close" size={24} color="white" accessibilityLabel={label} />
     </Button>
   )
@@ -85,7 +90,6 @@ const styles = StyleSheet.create({
   },
   closeButton: {
     position: 'absolute',
-    top: 60,
     right: 24,
     width: 32,
     height: 32,

--- a/app/src/screens/MainScreen/components/TutorialSkip.tsx
+++ b/app/src/screens/MainScreen/components/TutorialSkip.tsx
@@ -5,18 +5,20 @@ import { Button } from '../../../components/Button'
 import { StyleSheet } from 'react-native'
 import { useTutorial } from '../TutorialContext'
 import { useAccessibilityLabel } from '../../../hooks/useAccessibilityLabel'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export const TutorialSkip = () => {
   const { dispatch, steps } = useTutorial()
   const getAccessibilityLabel = useAccessibilityLabel()
   const label = getAccessibilityLabel('close')
+  const insets = useSafeAreaInsets()
 
   const onSkip = () => {
     dispatch({ type: 'skip', value: steps.length })
   }
 
   return (
-    <Button style={styles.button} status={'basic'} onPress={onSkip}>
+    <Button style={[styles.button, { top: insets.top + 12 }]} status={'basic'} onPress={onSkip}>
       <FontAwesome name="close" size={24} color="white" accessibilityLabel={label} />
     </Button>
   )
@@ -25,7 +27,6 @@ export const TutorialSkip = () => {
 const styles = StyleSheet.create({
   button: {
     position: 'absolute',
-    top: 60,
     right: 24,
     width: 32,
     height: 32,

--- a/app/src/screens/MainScreen/components/TutorialTextbox.tsx
+++ b/app/src/screens/MainScreen/components/TutorialTextbox.tsx
@@ -53,5 +53,6 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: 'bold',
     marginBottom: 8,
+    marginRight: 36,
   },
 })


### PR DESCRIPTION
## 📌 Summary
Fix modal close button overlapping text content on small screens by using dynamic safe area insets instead of hardcoded positioning, and adding right margin to tutorial title text.

## 🔗 Ticket / Issue
* #198 

## ✅ Changes
* [ ] Fix: Replaced hardcoded `top: 60` on `TutorialSkip` close button with dynamic `insets.top + 12` using `useSafeAreaInsets` to respect device safe areas
* [ ] Fix: Replaced hardcoded `top: 60` on `ModalCloseButton` with dynamic `insets.top + 12` using `useSafeAreaInsets` for consistent behavior across all modals
* [ ] Fix: Added `marginRight: 36` to `TutorialTextbox` title style to prevent text from rendering underneath the close button icon

## 🧪 Testing
<!-- Describe how you tested your changes -->
* Steps to reproduce:
1. Go to settings tab (4th tab)
2. Click on Parameters
3. Click on "launch" button of tutorial
4. Verify the close button is positioned at the top of the screen, on the same row area as the modal title
5. Verify the title text does not extend under the close button
6. Test on small screen devices / emulators (e.g. Samsung S21 FE)
7. Also verify any other modal in the app (e.g. info buttons, calendar day modal) has a properly positioned close button

* ✅ Expected result: Close button stays at the top of the screen respecting safe area insets, and title text has enough right margin to avoid being covered by the icon
* ❌ Bugs to watch out for: Verify on devices with varying notch/status bar sizes (Android + iOS) that `insets.top` provides correct spacing

## 📸 Screenshots (if applicable)

https://github.com/user-attachments/assets/4e4589b6-16f1-403a-abd6-0c5a931fee48

### Before
<!-- Screenshot or description -->
Close button uses fixed `top: 60`, causing it to overlap modal text content on small screens.

### After
<!-- Screenshot or description -->
Close button dynamically positions itself below the safe area with `insets.top + 12`, and the tutorial title has `marginRight: 36` to prevent text overlap.

## 📖 Notes for Reviewers
<!-- Anything special reviewers should focus on -->
- Three files changed: `TutorialSkip.tsx`, `TutorialTextbox.tsx`, `Modal.tsx`
- `useSafeAreaInsets` from `react-native-safe-area-context` was already a dependency in the project
- The fix applies to both the tutorial-specific close button (`TutorialSkip`) and the generic modal close button (`ModalCloseButton`), ensuring consistency across the app

---

### Checklist
* [ ] Code follows style guidelines
* [ ] Self-review completed
* [ ] Tests added/updated
* [ ] Documentation updated
* [ ] No sensitive info (keys, secrets, etc.) committed
