### PR TITLE
fix: prevent crash when navigating to EditProfile with null user

### DIFF
--- a/app/src/screens/EditProfileScreen/index.tsx
+++ b/app/src/screens/EditProfileScreen/index.tsx
@@ -139,7 +139,7 @@ const validateState = (state: EditProfileState): { isValid: boolean; errors: str
 }
 
 const EditProfileScreen: ScreenComponent<'EditProfile'> = ({ navigation }) => {
-  const currentUser = useSelector(currentUserSelector) as User
+  const currentUser = useSelector(currentUserSelector)
   const appToken = useSelector(appTokenSelector)
   const reduxDispatch = useDispatch()
   const { backgroundColor } = useColor()
@@ -148,10 +148,14 @@ const EditProfileScreen: ScreenComponent<'EditProfile'> = ({ navigation }) => {
   const [secretModalVisible, toggleSecretModal] = useToggle()
 
   const initialState = React.useMemo(() => {
+    if (!currentUser) return null
     return getInitialState(currentUser)
   }, [currentUser])
 
-  const [state, dispatch] = React.useReducer(reducer, initialState)
+  const [state, dispatch] = React.useReducer(
+    reducer,
+    initialState ?? ({ name: '', gender: '', month: NaN, year: 0, dateOfBirth: '', location: '' } as EditProfileState),
+  )
 
   const onChangeName = (value: string) => {
     dispatch({ type: 'name', value })
@@ -231,6 +235,10 @@ const EditProfileScreen: ScreenComponent<'EditProfile'> = ({ navigation }) => {
 
   const canConfirm = hasChanged && isValid
   const confirmStatus = canConfirm ? 'primary' : 'basic'
+
+  if (!currentUser || !initialState) {
+    return null
+  }
 
   return (
     <ScrollView contentContainerStyle={styles.screen}>


### PR DESCRIPTION
## 📌 Summary

The crash occurred because currentUser is null on initial mount before redux-persist finishes rehydrating the store from AsyncStorage. The Redux store itself is synchronous, but rehydration is async so on first render the store holds its default initial state where currentUser is null. 

Null guards were added to prevent fatal crashes.

## 🔗 Ticket / Issue

[OKY-23](https://rapp-unicef-oky.atlassian.net/browse/OKY-23)

## ✅ Changes

* [x] Fix: Null check on currentUser before calling getInitialState in EditProfileScreen
* [x] Fix: Early return null if currentUser or initialState is null, preventing render crash
* [x] Fix: Removed unsafe as User type cast on currentUserSelector

## 🧪 Testing

* Steps to reproduce:

1. Log in to platform
2. Navigate to the Profile Section, and click on Profile Data to edit.
3. App previously crashed, now renders safely.

* ✅ Expected result: No crash when currentUser is loading.

## 📖 Notes for Reviewers

Avoid using as Type casts to silence TypeScript, they hide real nullability issues. Prefer proper null checks or type guards instead.

### Checklist

* [x] Code follows style guidelines
* [x] Self-review completed
* [ ] Tests added/updated
* [ ] Documentation updated
* [x] No sensitive info (keys, secrets, etc.) committed
