### PR TITLE
Fix keyboard dismiss on daycard journal entry

### DIFF
--- a/app/src/navigation/components/Header.tsx
+++ b/app/src/navigation/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StyleSheet, View } from 'react-native'
+import { Keyboard, Pressable, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { Button } from '../../components/Button'
 import { NativeStackHeaderProps } from '@react-navigation/native-stack'
@@ -37,7 +37,7 @@ export const Header = ({ navigation, options, route }: HeaderProps) => {
   }
 
   return (
-    <View style={styles.wrapper}>
+    <Pressable onPress={Keyboard.dismiss} style={styles.wrapper}>
       <SafeAreaView style={styles.container}>
         {showBackButton ? (
           <Button onPress={onBackPress} style={styles.button} accessibilityLabel={label}>
@@ -55,7 +55,7 @@ export const Header = ({ navigation, options, route }: HeaderProps) => {
           </Text>
         )}
       </SafeAreaView>
-    </View>
+    </Pressable>
   )
 }
 

--- a/app/src/navigation/components/Header.tsx
+++ b/app/src/navigation/components/Header.tsx
@@ -37,7 +37,7 @@ export const Header = ({ navigation, options, route }: HeaderProps) => {
   }
 
   return (
-    <Pressable onPress={Keyboard.dismiss} style={styles.wrapper}>
+    <Pressable onPress={Keyboard.dismiss} accessible={false} style={styles.wrapper}>
       <SafeAreaView style={styles.container}>
         {showBackButton ? (
           <Button onPress={onBackPress} style={styles.button} accessibilityLabel={label}>

--- a/app/src/screens/DayScreen/components/DayTracker/NotesCard.tsx
+++ b/app/src/screens/DayScreen/components/DayTracker/NotesCard.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { Alert, KeyboardAvoidingView, StyleSheet, TouchableOpacity, View } from 'react-native'
+import {
+  Alert,
+  KeyboardAvoidingView,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native'
 import { Input } from '../../../../components/Input'
 import { Text } from '../../../../components/Text'
 import { Hr } from '../../../../components/Hr'
@@ -54,7 +60,10 @@ export const NotesCard = ({ dataEntry, goBack }: { dataEntry?: DayData; goBack?:
 
   return (
     <KeyboardAvoidingView style={[styles.container, { backgroundColor }]}>
-      <View style={styles.page}>
+      <ScrollView
+        contentContainerStyle={styles.page}
+        keyboardShouldPersistTaps="handled"
+      >
         <Input value={title} onChangeText={setTitle} placeholder="title" />
         <Input
           value={notes}
@@ -62,7 +71,7 @@ export const NotesCard = ({ dataEntry, goBack }: { dataEntry?: DayData; goBack?:
           placeholder="daily_note_description"
           multiline={true}
         />
-      </View>
+      </ScrollView>
       <Hr />
       <TouchableOpacity onPress={onPress} style={styles.confirm}>
         <Text style={styles.confirmText}>confirm</Text>
@@ -79,7 +88,7 @@ const styles = StyleSheet.create({
     borderRadius: 20,
   },
   page: {
-    flex: 1,
+    flexGrow: 1,
     width: '100%',
     flexDirection: 'column',
     paddingHorizontal: 24,

--- a/app/src/screens/DayScreen/index.tsx
+++ b/app/src/screens/DayScreen/index.tsx
@@ -35,7 +35,7 @@ const DayScreen: ScreenComponent<'Day'> = (props) => {
   }
 
   return (
-    <Pressable style={styles.flex} onPress={Keyboard.dismiss}>
+    <Pressable style={styles.flex} onPress={Keyboard.dismiss} accessible={false}>
       <FullScreen>
         {hasSurvey ? (
           <SurveyProvider survey={newSurvey} onFinish={onFinishSurvey}>

--- a/app/src/screens/DayScreen/index.tsx
+++ b/app/src/screens/DayScreen/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Keyboard, Pressable, StyleSheet } from 'react-native'
 import { ScreenComponent } from '../../navigation/RootNavigator'
 import { FullScreen } from '../../components/Screen'
 import { DayTracker } from './components/DayTracker'
@@ -34,16 +35,22 @@ const DayScreen: ScreenComponent<'Day'> = (props) => {
   }
 
   return (
-    <FullScreen>
-      {hasSurvey ? (
-        <SurveyProvider survey={newSurvey} onFinish={onFinishSurvey}>
-          <Survey />
-        </SurveyProvider>
-      ) : (
-        <DayTracker {...props} />
-      )}
-    </FullScreen>
+    <Pressable style={styles.flex} onPress={Keyboard.dismiss}>
+      <FullScreen>
+        {hasSurvey ? (
+          <SurveyProvider survey={newSurvey} onFinish={onFinishSurvey}>
+            <Survey />
+          </SurveyProvider>
+        ) : (
+          <DayTracker {...props} />
+        )}
+      </FullScreen>
+    </Pressable>
   )
 }
+
+const styles = StyleSheet.create({
+  flex: { flex: 1, width: '100%' },
+})
 
 export default DayScreen


### PR DESCRIPTION
## Summary
- Allow dismissing the keyboard by tapping outside text inputs on the NotesCard (journal/diary) screen
- Tapping inside the card, on the background around the card, or on the header bar all dismiss the keyboard

## Ticket/Issue
Closes https://github.com/Oky-period-tracker/periodtracker/issues/218

## Changes
- **NotesCard.tsx**: Replaced inner `View` with `ScrollView` using `keyboardShouldPersistTaps="handled"` so tapping empty areas inside the card dismisses the keyboard. Changed `flex: 1` to `flexGrow: 1` for proper ScrollView sizing.
- **DayScreen/index.tsx**: Wrapped `FullScreen` with a `Pressable` that calls `Keyboard.dismiss` on press, covering the background area around the card.
- **Header.tsx**: Replaced outer `View` with `Pressable` that calls `Keyboard.dismiss`, so tapping the header bar also dismisses the keyboard.

## Testing
- Verified on physical device (Samsung S24 Ultra, Android) via wireless ADB
- Keyboard opens when tapping title or notes input
- Keyboard dismisses when tapping: empty area inside the card, background around the card, header bar
- Confirm button still works correctly
- Swiping between cards still works

## Screenshots

### Before (keyboard stays open when tapping outside)

https://github.com/user-attachments/assets/56ee73ca-d629-40ae-a6ad-4af41c3dfe48

### After (keyboard dismisses on tap outside)

https://github.com/user-attachments/assets/9ca41b51-9afe-4306-b356-a4d028a03b0f

## Notes
- `Keyboard.dismiss()` is a no-op when no keyboard is shown, so the Header and DayScreen changes are harmless for screens without text inputs