### PR TITLE
[FEAT] Small changes for survey feedback screens

### DIFF
--- a/app/src/core/types/translations/app.ts
+++ b/app/src/core/types/translations/app.ts
@@ -11,7 +11,6 @@ export interface AppTranslations {
   activity: string
   age: string
   alert: string
-  anonymous_answer: string
   Apr: string
   April: string
   are_you_sure: string
@@ -51,7 +50,6 @@ export interface AppTranslations {
   characters: string
   childhood_hero: string
   choose_avatar: string
-  choose_one: string
   clear_filters: string
   clear_search: string
   close_tooltip_button: string
@@ -59,6 +57,7 @@ export interface AppTranslations {
   confirm: string
   confirm_and_delete: string
   confirm_password: string
+  end: string
   connect_account: string
   connect_account_info: string
   contact_us: string

--- a/app/src/screens/DayScreen/components/Survey/index.tsx
+++ b/app/src/screens/DayScreen/components/Survey/index.tsx
@@ -52,19 +52,14 @@ export const Survey = () => {
             </Text>
           ) : state.consented ? (
             <>
-              <Text
-                style={[styles.question, { color: '#000000' }]}
-                enableTranslate={false}
-              >
+              <Text style={styles.question} enableTranslate={false}>
                 {question}
               </Text>
               <SurveyCollect />
             </>
           ) : (
             <>
-              <Text style={[styles.question, { color: '#000000' }]}>
-                {consentQuestion}
-              </Text>
+              <Text style={styles.question}>{consentQuestion}</Text>
               <SurveyConsent />
             </>
           )}

--- a/app/src/screens/DayScreen/components/Survey/index.tsx
+++ b/app/src/screens/DayScreen/components/Survey/index.tsx
@@ -46,9 +46,6 @@ export const Survey = () => {
             <Text style={[styles.title, { color: palette.secondary.text }]}>survey</Text>
             <InfoButton title={'survey'} content={'info_button_survey'} />
           </View>
-          <Text>anonymous_answer</Text>
-          <Text>choose_one</Text>
-
           {state.hasAnsweredAll ? (
             <Text style={styles.thanks} status={'danger'}>
               thank_you_msg
@@ -56,7 +53,7 @@ export const Survey = () => {
           ) : state.consented ? (
             <>
               <Text
-                style={[styles.question, { color: palette.secondary.text }]}
+                style={[styles.question, { color: '#000000' }]}
                 enableTranslate={false}
               >
                 {question}
@@ -65,7 +62,7 @@ export const Survey = () => {
             </>
           ) : (
             <>
-              <Text style={[styles.question, { color: palette.secondary.text }]}>
+              <Text style={[styles.question, { color: '#000000' }]}>
                 {consentQuestion}
               </Text>
               <SurveyConsent />
@@ -85,7 +82,9 @@ export const Survey = () => {
           </>
         )}
         <TouchableOpacity onPress={onConfirm} style={styles.button}>
-          <Text style={styles.buttonText}>{isLastQuestion ? 'submit' : 'confirm'}</Text>
+          <Text style={styles.buttonText}>
+            {state.hasAnsweredAll ? 'end' : isLastQuestion ? 'submit' : 'confirm'}
+          </Text>
         </TouchableOpacity>
       </View>
     </View>


### PR DESCRIPTION
## 📌 Summary

Small UI/text changes to the survey (feedback) screens as requested in #226.

## 🔗 Ticket / Issue

* GitHub Issue: [#226](https://github.com/Oky-period-tracker/periodtracker/issues/226)

## ✅ Changes

* [x] Feature: Removed "Tell us about your experience with Oky. Choose one option from the list" text from all survey screens
* [x] Feature: Changed the key question text color from orange to black so it no longer matches the "Feedback" title
* [x] Feature: Changed the button text on the final (thank-you) card from "Confirm" to "End"
* [x] Other: Added "end" translation key to all 5 language files (en, fr, es, pt, ru)

## 🧪 Testing

* Steps to reproduce:

1. Log in and navigate to the Day screen with an active survey
2. Verify the "tell us about your experience" text is gone
3. Verify the question text is black, not orange
4. Complete the survey and verify the final card button says "End"

* ✅ Expected result: All three text/style changes are visible on the survey screens
* ❌ Bugs to watch out for: Survey must be active in the database for the feedback card to appear

## 📸 Screenshots (if applicable)

### Before

**Consent screen:** Shows orange question text and "Tell us about your experience" text

<img width="300" alt="image" src="https://github.com/user-attachments/assets/e2f36777-07d3-46df-90e7-854c08ce2539" />

**Final card:** Shows "Confirm" button and experience text

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3272a96a-78dc-4fd7-9adc-a1c91e3cb9c1" />

### After

**Consent screen:** Question text is black, experience text removed

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b873f60b-986f-4bfa-843a-50e2a0678e9a" />

**Final card:** Button now says "End", experience text removed

<img width="300" alt="image" src="https://github.com/user-attachments/assets/62384f2b-f711-4133-acea-bafbb2dced7a" />

## 📖 Notes for Reviewers

Translation changes are in the resources submodule (branch: feat/survey-end-translation on TaiKamilla/periodtracker_resources-global).

---

### Checklist

* [x] Code follows style guidelines
* [x] Self-review completed
* [ ] Tests added/updated
* [x] Documentation updated
* [x] No sensitive info (keys, secrets, etc.) committed