### PR TITLE
fix: rebuild cycle history from verified period dates

### DIFF
--- a/app/__tests__/src/prediction/historyReconciliation.test.ts
+++ b/app/__tests__/src/prediction/historyReconciliation.test.ts
@@ -1,0 +1,151 @@
+import moment from 'moment'
+import {
+  detectPeriodClusters,
+  shouldReconcileHistory,
+  buildPredictionFromVerifiedDates,
+  reconcileHistoryWithVerifiedDates,
+} from '../../../src/prediction/historyReconciliation'
+
+type VerifiedDates = Record<string, { periodDay: boolean }>
+
+function makePeriods(options: {
+  firstStart: string
+  cycles: number
+  cycleLength: number
+  periodLength: number
+}): VerifiedDates {
+  const { firstStart, cycles, cycleLength, periodLength } = options
+  const dates: VerifiedDates = {}
+  const start = moment(firstStart, 'YYYYMMDD')
+  for (let c = 0; c < cycles; c++) {
+    const cycleStart = start.clone().add(c * cycleLength, 'days')
+    for (let d = 0; d < periodLength; d++) {
+      dates[cycleStart.clone().add(d, 'days').format('YYYYMMDD')] = { periodDay: true }
+    }
+  }
+  return dates
+}
+
+describe('detectPeriodClusters', () => {
+  it('returns nothing for empty input', () => {
+    expect(detectPeriodClusters(undefined)).toEqual([])
+    expect(detectPeriodClusters({})).toEqual([])
+  })
+
+  it('ignores periodDay false entries', () => {
+    expect(detectPeriodClusters({ '20250101': { periodDay: false } })).toEqual([])
+  })
+
+  it('merges a 1 day intra-period gap into one cluster', () => {
+    const clusters = detectPeriodClusters({
+      '20250101': { periodDay: true },
+      // 20250102 missing
+      '20250103': { periodDay: true },
+    })
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0].length).toBe(3)
+  })
+
+  it('splits clusters when the gap exceeds the threshold', () => {
+    const verified = makePeriods({
+      firstStart: '20250101',
+      cycles: 3,
+      cycleLength: 28,
+      periodLength: 4,
+    })
+    const clusters = detectPeriodClusters(verified)
+    expect(clusters).toHaveLength(3)
+    expect(clusters.every((c) => c.length === 4)).toBe(true)
+  })
+})
+
+describe('shouldReconcileHistory and reconcileHistoryWithVerifiedDates', () => {
+  it('does nothing when history already matches the verified dates', () => {
+    const verified = makePeriods({
+      firstStart: '20260101',
+      cycles: 3,
+      cycleLength: 28,
+      periodLength: 4,
+    })
+    const matchingState = {
+      isActive: true,
+      currentCycle: {
+        startDate: moment('20260225', 'YYYYMMDD').toISOString(),
+        periodLength: 4,
+        cycleLength: 28,
+      },
+      smartPrediction: {
+        circularPeriodLength: [],
+        circularCycleLength: [],
+        smaPeriodLength: 4,
+        smaCycleLength: 28,
+      },
+      futurePredictionStatus: true,
+      history: [{}, {}],
+      actualCurrentStartDate: null,
+    }
+    expect(shouldReconcileHistory(matchingState, verified)).toBe(false)
+    expect(reconcileHistoryWithVerifiedDates(matchingState, verified)).toBeNull()
+  })
+
+  it('rebuilds the missing cycles when history is sparse', () => {
+    const verified = makePeriods({
+      firstStart: '20250101',
+      cycles: 12,
+      cycleLength: 30,
+      periodLength: 5,
+    })
+    const sparseState = {
+      isActive: true,
+      currentCycle: {
+        startDate: moment('20251127', 'YYYYMMDD').toISOString(),
+        periodLength: 5,
+        cycleLength: 30,
+      },
+      smartPrediction: {
+        circularPeriodLength: [],
+        circularCycleLength: [],
+        smaPeriodLength: 5,
+        smaCycleLength: 30,
+      },
+      futurePredictionStatus: true,
+      history: [],
+      actualCurrentStartDate: null,
+    }
+    expect(shouldReconcileHistory(sparseState, verified)).toBe(true)
+
+    const rebuilt = reconcileHistoryWithVerifiedDates(sparseState, verified)
+    expect(rebuilt).not.toBeNull()
+    if (!rebuilt) return
+    expect(rebuilt.history).toHaveLength(11)
+    expect(rebuilt.currentCycle.startDate.format('YYYYMMDD')).toBe('20251127')
+    expect(rebuilt.currentCycle.periodLength).toBe(5)
+    expect(rebuilt.history[0].cycleStartDate.format('YYYYMMDD')).toBe('20251028')
+    expect(rebuilt.history[rebuilt.history.length - 1].cycleStartDate.format('YYYYMMDD')).toBe(
+      '20250101',
+    )
+  })
+
+  it('does not rebuild with fewer than two clusters', () => {
+    const verified = { '20250101': { periodDay: true }, '20250102': { periodDay: true } }
+    expect(buildPredictionFromVerifiedDates(verified)).toBeNull()
+  })
+
+  it('preserves engine flags from the existing state', () => {
+    const verified = makePeriods({
+      firstStart: '20260101',
+      cycles: 3,
+      cycleLength: 28,
+      periodLength: 3,
+    })
+    const rebuilt = buildPredictionFromVerifiedDates(verified, {
+      isActive: true,
+      futurePredictionStatus: false,
+      actualCurrentStartDate: { foo: 'bar' },
+    })
+    expect(rebuilt).not.toBeNull()
+    if (!rebuilt) return
+    expect(rebuilt.futurePredictionStatus).toBe(false)
+    expect(rebuilt.actualCurrentStartDate).toEqual({ foo: 'bar' })
+  })
+})

--- a/app/src/contexts/PredictionProvider.tsx
+++ b/app/src/contexts/PredictionProvider.tsx
@@ -4,11 +4,16 @@
 import React from 'react'
 import moment, { Moment } from 'moment'
 import _ from 'lodash'
-import { PredictionState, PredictionEngine } from '../prediction'
+import {
+  PredictionState,
+  PredictionEngine,
+  reconcileHistoryWithVerifiedDates,
+} from '../prediction'
 
 import { useDispatch } from 'react-redux'
 import * as actions from '../redux/actions'
 import { useSelector } from '../redux/useSelector'
+import { allCardAnswersSelector } from '../redux/selectors/answerSelectors'
 
 type PredictionDispatch = typeof PredictionEngine.prototype.userInputDispatch
 
@@ -29,6 +34,9 @@ const defaultState = PredictionState.fromData({
 export function PredictionProvider({ children }) {
   const reduxDispatch = useDispatch()
   const predictionState = useSelector((state) => state.prediction)
+  const verifiedDates = useSelector(allCardAnswersSelector)
+  const currentUserId = useSelector((state) => state.auth.user?.id ?? null)
+  const reconciledUserRef = React.useRef<string | null>(null)
 
   const [predictionSnapshots, setPredictionSnapshots] = React.useState([])
 
@@ -55,6 +63,22 @@ export function PredictionProvider({ children }) {
       reduxDispatch(actions.setPredictionEngineState(nextPredictionState))
     })
   }, [reduxDispatch, predictionEngine])
+
+  // Rebuild missing cycle history from verified period dates.
+  // Some users have many verified period days but a sparse history (data loss
+  // after migration or sync issues). Run once per logged-in user.
+  React.useEffect(() => {
+    if (!currentUserId) return
+    if (reconciledUserRef.current === currentUserId) return
+    if (!predictionState?.currentCycle) return
+    if (!verifiedDates || Object.keys(verifiedDates).length === 0) return
+
+    const rebuilt = reconcileHistoryWithVerifiedDates(predictionState, verifiedDates)
+    if (rebuilt) {
+      reduxDispatch(actions.setPredictionEngineState(rebuilt))
+    }
+    reconciledUserRef.current = currentUserId
+  }, [currentUserId, predictionState, verifiedDates, reduxDispatch])
 
   const undo = React.useCallback(() => {
     if (predictionSnapshots.length > 0) {

--- a/app/src/prediction/historyReconciliation.ts
+++ b/app/src/prediction/historyReconciliation.ts
@@ -1,0 +1,152 @@
+import moment, { Moment } from 'moment'
+import { PredictionState, PredictionSerializableState } from './PredictionState'
+import { VerifiedDates } from '../redux/reducers/answerReducer'
+
+const MAX_INTRA_PERIOD_GAP_DAYS = 2
+const DEFAULT_CYCLE_LENGTH = 28
+const MIN_CLUSTERS_FOR_REBUILD = 2
+
+interface PeriodCluster {
+  start: Moment
+  end: Moment
+  length: number
+}
+
+export function detectPeriodClusters(verifiedDates: VerifiedDates | undefined): PeriodCluster[] {
+  if (!verifiedDates) {
+    return []
+  }
+
+  const periodDates: Moment[] = []
+  for (const [dateKey, data] of Object.entries(verifiedDates)) {
+    if (data && data.periodDay === true) {
+      const parsed = moment(dateKey, 'YYYYMMDD', true).startOf('day')
+      if (parsed.isValid()) {
+        periodDates.push(parsed)
+      }
+    }
+  }
+
+  if (periodDates.length === 0) {
+    return []
+  }
+
+  periodDates.sort((a, b) => a.valueOf() - b.valueOf())
+
+  const clusters: PeriodCluster[] = []
+  let clusterStart = periodDates[0]
+  let clusterEnd = periodDates[0]
+
+  for (let i = 1; i < periodDates.length; i++) {
+    const daysDiff = periodDates[i].diff(periodDates[i - 1], 'days')
+    if (daysDiff <= MAX_INTRA_PERIOD_GAP_DAYS) {
+      clusterEnd = periodDates[i]
+    } else {
+      clusters.push({
+        start: clusterStart,
+        end: clusterEnd,
+        length: clusterEnd.diff(clusterStart, 'days') + 1,
+      })
+      clusterStart = periodDates[i]
+      clusterEnd = periodDates[i]
+    }
+  }
+  clusters.push({
+    start: clusterStart,
+    end: clusterEnd,
+    length: clusterEnd.diff(clusterStart, 'days') + 1,
+  })
+
+  return clusters
+}
+
+export function shouldReconcileHistory(
+  currentState: Pick<PredictionSerializableState, 'history'> | null | undefined,
+  verifiedDates: VerifiedDates | undefined,
+): boolean {
+  const clusters = detectPeriodClusters(verifiedDates)
+  if (clusters.length < MIN_CLUSTERS_FOR_REBUILD) {
+    return false
+  }
+  const historyCount = currentState && currentState.history ? currentState.history.length : 0
+  return clusters.length > historyCount + 1
+}
+
+export function buildPredictionFromVerifiedDates(
+  verifiedDates: VerifiedDates | undefined,
+  existingState?: Partial<
+    Pick<PredictionSerializableState, 'isActive' | 'futurePredictionStatus' | 'actualCurrentStartDate'>
+  >,
+): PredictionState | null {
+  const clusters = detectPeriodClusters(verifiedDates)
+  if (clusters.length < MIN_CLUSTERS_FOR_REBUILD) {
+    return null
+  }
+
+  const cycleLengths: number[] = []
+  for (let i = 0; i < clusters.length - 1; i++) {
+    cycleLengths.push(clusters[i + 1].start.diff(clusters[i].start, 'days'))
+  }
+
+  const periodLengths = clusters.map((c) => c.length)
+
+  const history = []
+  for (let i = 0; i < clusters.length - 1; i++) {
+    history.push({
+      cycleStartDate: clusters[i].start.clone(),
+      cycleEndDate: clusters[i + 1].start.clone().subtract(1, 'days'),
+      periodLength: clusters[i].length,
+      cycleLength: cycleLengths[i],
+    })
+  }
+  // Engine convention: history ordered newest first
+  history.reverse()
+
+  const lastCluster = clusters[clusters.length - 1]
+  const avgCycleLength = cycleLengths.length
+    ? Math.round(cycleLengths.reduce((a, b) => a + b, 0) / cycleLengths.length)
+    : DEFAULT_CYCLE_LENGTH
+  const avgPeriodLength = Math.round(
+    periodLengths.reduce((a, b) => a + b, 0) / periodLengths.length,
+  )
+
+  const state = PredictionState.fromData({
+    isActive: existingState && existingState.isActive !== undefined ? existingState.isActive : true,
+    startDate: lastCluster.start.clone(),
+    periodLength: lastCluster.length,
+    cycleLength: avgCycleLength,
+    smaPeriodLength: avgPeriodLength,
+    smaCycleLength: avgCycleLength,
+    history,
+    futurePredictionStatus:
+      existingState && existingState.futurePredictionStatus !== undefined
+        ? existingState.futurePredictionStatus
+        : true,
+    actualCurrentStartDate:
+      existingState && existingState.actualCurrentStartDate !== undefined
+        ? existingState.actualCurrentStartDate
+        : null,
+  })
+
+  // Match the engine's circular buffer size of 6
+  const tailPeriods = periodLengths.slice(-6)
+  const tailCycles = cycleLengths.slice(-6)
+  for (const v of tailPeriods) {
+    state.smartPrediction.circularPeriodLength.push(v)
+  }
+  for (const v of tailCycles) {
+    state.smartPrediction.circularCycleLength.push(v)
+  }
+
+  return state
+}
+
+export function reconcileHistoryWithVerifiedDates(
+  currentState: PredictionSerializableState | null | undefined,
+  verifiedDates: VerifiedDates | undefined,
+): PredictionState | null {
+  if (!shouldReconcileHistory(currentState, verifiedDates)) {
+    return null
+  }
+  return buildPredictionFromVerifiedDates(verifiedDates, currentState || undefined)
+}

--- a/app/src/prediction/index.ts
+++ b/app/src/prediction/index.ts
@@ -1,2 +1,3 @@
 export * from './PredictionEngine'
 export * from './PredictionState'
+export * from './historyReconciliation'


### PR DESCRIPTION
## 📌 Summary

Some users open the app and find their cycles tab showing only a single cycle (or none) even though their calendar still has all the period days they logged. The verified dates are intact in storage, but the prediction `history` array got truncated by an earlier sync, migration, or upgrade. This change rebuilds the missing history from the verified dates on login so the cycles tab matches what the user actually logged.

## 🔗 Ticket / Issue

* GitHub Issue: [#237](https://github.com/Oky-period-tracker/periodtracker/issues/237)

## ✅ Changes

* [x] Fix: `PredictionProvider` now reconciles `state.prediction.history` against `state.answer[userId].verifiedDates` once per logged-in user. When more period clusters are detected in verified dates than the engine has cycles, the prediction state is rebuilt and dispatched, then the engine takes over normally.
* [x] Fix: New utility `app/src/prediction/historyReconciliation.ts` exposes `detectPeriodClusters`, `shouldReconcileHistory`, `buildPredictionFromVerifiedDates`, and the higher-level `reconcileHistoryWithVerifiedDates`. Clusters allow up to a 1-day intra-period gap so a single forgotten log does not split a real period.
* [x] Tests: 8 unit tests covering cluster detection, the trigger heuristic, sparse-history rebuild, and engine-flag preservation. Verified period payloads are generated by a `makePeriods` helper instead of hardcoded fixtures.

## 🧪 Testing

Steps to reproduce the bug (manual):
1. Take a user account with rich verified dates but sparse `prediction.history` (e.g. seed the `oky_user.store` JSON with the payload from issue #237).
2. Log in as that user, open the cycles tab.
3. Before the fix: only the cycles known to `state.prediction.history` render.
4. After the fix: every cycle implied by the verified dates renders, with the most recent period as the current cycle.

Automated:
* `cd app && yarn jest --testPathPattern=historyReconciliation` runs the new suite.
* The `rebuilds the missing cycles when history is sparse` test seeds 12 generated periods, leaves history empty, and asserts 11 history entries plus the current cycle.

* ✅ Expected result: cycles tab lists every cycle the user logged.
* ❌ Bugs to watch out for: very fragmented period logs with consistent 3+ day gaps would be grouped into a single cycle. The current heuristic only merges runs separated by at most one missed day.

## 📸 Screenshots

### Before

https://github.com/user-attachments/assets/1ee4e78d-c231-4310-955e-5586b139d1c6

### After

https://github.com/user-attachments/assets/859b2a22-d259-4096-8f2d-31c7bf6614a8

## 📖 Notes for Reviewers

* Reconciliation runs once per user via a ref keyed on user id, so logging out and logging back in as a different user re-triggers the check.
* The rebuild only fires when `verifiedDates` contains more period clusters than `history.length + 1`, so accounts whose history is already correct are unaffected.
* History entries are emitted newest-first to match the existing engine convention. Smart prediction circular buffers and SMA values are repopulated from the recovered cycle and period lengths.

---

### Checklist

* [x] Code follows style guidelines
* [x] Self-review completed
* [x] Tests added/updated
* [ ] Documentation updated
* [x] No sensitive info (keys, secrets, etc.) committed