### PR TITLE
[FIX] Avatar wave animation for accessories V2

### DIFF
--- a/app/src/components/Avatar/Avatar.styles.ts
+++ b/app/src/components/Avatar/Avatar.styles.ts
@@ -16,6 +16,7 @@ export const getAvatarContainerBottomStyle = (bottomOffset: number): ViewStyle =
 
 export const getCustomAvatarScaleStyle = (scale: number): ViewStyle => ({
   transform: [{ scale }],
+  overflow: 'visible',
 })
 
 export const getLottieViewStyle = (width: number, height: number): ViewStyle => ({

--- a/app/src/components/Avatar/index.tsx
+++ b/app/src/components/Avatar/index.tsx
@@ -345,6 +345,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     position: 'relative',
     zIndex: 3,
+    overflow: 'visible',
   },
   cloudsWrapper: {
     position: 'absolute',

--- a/app/src/components/AvatarPreview/AnimatedAvatarPreview.tsx
+++ b/app/src/components/AvatarPreview/AnimatedAvatarPreview.tsx
@@ -276,6 +276,6 @@ export const AnimatedAvatarPreview: React.FC<BaseAvatarPreviewProps> = (props) =
 
 const styles = StyleSheet.create({
   container: {
-    // Container for animated avatar
+    overflow: 'visible',
   },
 })

--- a/app/src/components/AvatarPreview/index.tsx
+++ b/app/src/components/AvatarPreview/index.tsx
@@ -253,6 +253,7 @@ export const AvatarPreview: React.FC<AvatarPreviewProps> = ({
             style={[
               styles.layer,
               isProstheticDevice ? styles.deviceLayerProsthetic : styles.deviceLayer,
+              { overflow: 'visible' },
             ]}
           >
             {renderSvg(svg, { width, height, animatedTransforms })}
@@ -285,6 +286,7 @@ const styles = StyleSheet.create({
     position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
+    overflow: 'visible',
   },
   layer: {
     position: 'absolute',

--- a/app/src/components/AvatarPreview/index.tsx
+++ b/app/src/components/AvatarPreview/index.tsx
@@ -183,7 +183,7 @@ export const AvatarPreview: React.FC<AvatarPreviewProps> = ({
   }
 
   return (
-    <View style={[styles.container, { width, height }, style]}>
+    <View pointerEvents="none" style={[styles.container, { width, height }, style]}>
       {/* Body layer with skin color */}
       {BodyComponent && (
         <View style={[styles.layer, styles.bodyLayer]}>


### PR DESCRIPTION
## 📌 Summary

This change updates the friend avatar so that hand-mounted accessories and clothing sleeves move together with the arms during the wave and jump animations. The body and arms already animated, but the items attached to the arms remained painted on the torso and slid out of alignment whenever the arms moved.

## 🔗 Ticket / Issue

* GitHub Issue: [#219](https://github.com/Oky-period-tracker/periodtracker/issues/219)

## ✅ Changes

* [x] Fix: Set `overflow: 'visible'` in five places across the avatar render tree (`app/src/components/Avatar/Avatar.styles.ts`, `app/src/components/Avatar/index.tsx`, `app/src/components/AvatarPreview/index.tsx` container and prosthetic device layer, `app/src/components/AvatarPreview/AnimatedAvatarPreview.tsx`) so the rendered avatar layers are not cut off at the wrapping React Native View boundary while parts rotate
* [x] Fix: Mark the outer `AvatarPreview` wrapper as `pointerEvents="none"` so its bounding box does not absorb touches meant for the category selector underneath in the custom avatar builder
* [x] Bump the `app/src/resources` submodule pointer so the friend avatar pulls in the updated device and clothing components that expose the per-limb animation transforms

## 🧪 Testing

* Steps to reproduce:

1. Build and run the app
2. Sign in and open the friend avatar customization flow
3. From the device category, pick one of the prosthetic arm, cane, or purse items and save
4. Return to the main screen and observe the avatar greeting animation
5. Repeat with the prosthetic leg device
6. Repeat with each clothing item that has visible sleeves, including the short variants and the heavily decorated traditional dresses
7. Reopen the custom avatar builder and verify that switching between the body, hair, eyes, clothing, and device tabs still responds to taps

* ✅ Expected result: every accessory and sleeve travels with the arm it is attached to during the wave and jump, no item appears clipped at the edge of the avatar frame, and the category selector underneath the preview accepts taps as usual.
* ❌ Bugs to watch out for: the preview frame catching taps meant for the tabs below it; any accessory or sleeve briefly disappearing at the extremes of the rotation arc.

## 📸 Screenshots (if applicable)

https://github.com/user-attachments/assets/6095ec05-57de-4a68-85a1-0bf70a3079d0

## 📖 Notes for Reviewers

* The container changes are scoped to the avatar render tree. Nothing else in the app relies on those views being a clipping boundary, so widening them to `overflow: 'visible'` should not cascade.
* The `pointerEvents="none"` change is needed because the avatar preview is positioned on top of the category selector with some padding. Once the preview is allowed to draw outside its frame, its hit area overlaps the buttons below until touches are explicitly disabled on the wrapper.
* The submodule bump is the carrier for the visual content; the per-limb shared values defined inside `AnimatedAvatarPreview` only have an effect once the components in the resources package read them, which is what the new pointer adds.

---

### Checklist

* [x] Code follows style guidelines
* [x] Self-review completed
* [ ] Tests added/updated
* [x] Documentation updated
* [x] No sensitive info (keys, secrets, etc.) committed