### PR TITLE
[Feat] Offline multiuser

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -17,12 +17,18 @@ import { StatusBar } from 'react-native'
 import { analytics } from './src/services/firebase'
 import { ReducedMotionConfig, ReduceMotion } from 'react-native-reanimated'
 import { SoundProvider } from './src/contexts/SoundProvider'
+import { startSyncWatcher } from './src/services/sync/syncManager'
 
 function App() {
   useOrientationLock()
 
   React.useEffect(() => {
     analytics?.().logAppOpen()
+  }, [])
+
+  React.useEffect(() => {
+    // Sync offline-created accounts to the server when online.
+    return startSyncWatcher()
   }, [])
 
   return (

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -31,9 +31,9 @@ function App() {
       <GestureHandlerRootView style={{ flex: 1 }}>
         <StoreManagerProvider>
           {(bundle) => (
-            <Provider store={bundle.store}>
-              <PersistGate key={bundle.userId} loading={null} persistor={bundle.persistor}>
-                <AuthProvider>
+            <AuthProvider>
+              <Provider store={bundle.store}>
+                <PersistGate key={bundle.userId} loading={null} persistor={bundle.persistor}>
                   <PredictionProvider>
                     <ResponsiveProvider>
                       <SoundProvider>
@@ -48,9 +48,9 @@ function App() {
                       </SoundProvider>
                     </ResponsiveProvider>
                   </PredictionProvider>
-                </AuthProvider>
-              </PersistGate>
-            </Provider>
+                </PersistGate>
+              </Provider>
+            </AuthProvider>
           )}
         </StoreManagerProvider>
       </GestureHandlerRootView>

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -4,7 +4,7 @@ import RootNavigator from './src/navigation/RootNavigator'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { Background } from './src/components/Background'
 import { Provider } from 'react-redux'
-import { store, persistor } from './src/redux/store'
+import { StoreManagerProvider } from './src/redux/StoreManagerContext'
 import { PersistGate } from 'redux-persist/integration/react'
 import { useOrientationLock } from './src/hooks/useOrientationLock'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
@@ -29,26 +29,30 @@ function App() {
     <SafeAreaProvider>
       <ReducedMotionConfig mode={ReduceMotion.Never} />
       <GestureHandlerRootView style={{ flex: 1 }}>
-        <Provider store={store}>
-          <PersistGate loading={null} persistor={persistor}>
-            <AuthProvider>
-              <PredictionProvider>
-                <ResponsiveProvider>
-                  <SoundProvider>
-                    <EncyclopediaProvider>
-                      <Background>
-                        <LoadingProvider>
-                          <StatusBar hidden />
-                          <RootNavigator />
-                        </LoadingProvider>
-                      </Background>
-                    </EncyclopediaProvider>
-                  </SoundProvider>
-                </ResponsiveProvider>
-              </PredictionProvider>
-            </AuthProvider>
-          </PersistGate>
-        </Provider>
+        <StoreManagerProvider>
+          {(bundle) => (
+            <Provider store={bundle.store}>
+              <PersistGate key={bundle.userId} loading={null} persistor={bundle.persistor}>
+                <AuthProvider>
+                  <PredictionProvider>
+                    <ResponsiveProvider>
+                      <SoundProvider>
+                        <EncyclopediaProvider>
+                          <Background>
+                            <LoadingProvider>
+                              <StatusBar hidden />
+                              <RootNavigator />
+                            </LoadingProvider>
+                          </Background>
+                        </EncyclopediaProvider>
+                      </SoundProvider>
+                    </ResponsiveProvider>
+                  </PredictionProvider>
+                </AuthProvider>
+              </PersistGate>
+            </Provider>
+          )}
+        </StoreManagerProvider>
       </GestureHandlerRootView>
     </SafeAreaProvider>
   )

--- a/app/__tests__/src/services/userMetadata/registry.test.ts
+++ b/app/__tests__/src/services/userMetadata/registry.test.ts
@@ -1,0 +1,81 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { MAX_ACCOUNTS_PER_DEVICE } from '../../../../src/services/userMetadata/types'
+
+// credentialVault pulls in the Keychain/crypto native modules at import time (via encryptionKeys),
+// and is only used by removeUser — not the per-device limit path under test. Stub it out.
+jest.mock('../../../../src/services/auth/credentialVault', () => ({
+  deleteCredential: jest.fn(),
+}))
+
+// storeManager is lazy-required by removeUser only; stub it so the import cannot pull native deps.
+jest.mock('../../../../src/redux/storeManager', () => ({
+  purgeUserStorage: jest.fn(),
+}))
+
+import {
+  MAX_ACCOUNTS_ERROR,
+  addUser,
+  listUsers,
+  userCount,
+  removeUser,
+  getUser,
+} from '../../../../src/services/userMetadata/registry'
+
+const makeUser = (id: string) => ({
+  id,
+  name: `User ${id}`,
+  deviceId: 'device-1',
+  isPendingSync: true,
+})
+
+describe('account registry per-device limit', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear()
+  })
+
+  it('allows adding up to MAX_ACCOUNTS_PER_DEVICE accounts', async () => {
+    for (let i = 0; i < MAX_ACCOUNTS_PER_DEVICE; i++) {
+      await addUser(makeUser(`u${i}`))
+    }
+
+    expect(await userCount()).toBe(MAX_ACCOUNTS_PER_DEVICE)
+  })
+
+  it('throws MAX_ACCOUNTS_ERROR when adding one account over the limit', async () => {
+    for (let i = 0; i < MAX_ACCOUNTS_PER_DEVICE; i++) {
+      await addUser(makeUser(`u${i}`))
+    }
+
+    await expect(addUser(makeUser('overflow'))).rejects.toThrow(MAX_ACCOUNTS_ERROR)
+    // The rejected add must not be persisted.
+    expect(await userCount()).toBe(MAX_ACCOUNTS_PER_DEVICE)
+    expect(await getUser('overflow')).toBeNull()
+  })
+
+  it('does not count re-adding an existing account against the limit', async () => {
+    for (let i = 0; i < MAX_ACCOUNTS_PER_DEVICE; i++) {
+      await addUser(makeUser(`u${i}`))
+    }
+
+    // Re-adding an account that already exists (same id) is an update, not a new slot.
+    await expect(
+      addUser({ ...makeUser('u0'), name: 'Renamed' }),
+    ).resolves.toMatchObject({ id: 'u0', name: 'Renamed' })
+
+    const users = await listUsers()
+    expect(users).toHaveLength(MAX_ACCOUNTS_PER_DEVICE)
+    expect(users.find((u) => u.id === 'u0')?.name).toBe('Renamed')
+  })
+
+  it('frees a slot after removing an account', async () => {
+    for (let i = 0; i < MAX_ACCOUNTS_PER_DEVICE; i++) {
+      await addUser(makeUser(`u${i}`))
+    }
+    await expect(addUser(makeUser('overflow'))).rejects.toThrow(MAX_ACCOUNTS_ERROR)
+
+    await removeUser('u0')
+
+    await expect(addUser(makeUser('overflow'))).resolves.toMatchObject({ id: 'overflow' })
+    expect(await userCount()).toBe(MAX_ACCOUNTS_PER_DEVICE)
+  })
+})

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -19,6 +19,8 @@ const esModules = [
   'react-native-size-matters',
   'react-native-calendars',
   'expo-constants',
+  'expo-device',
+  'expo-application',
 ].join('|')
 
 module.exports = {

--- a/app/package.json
+++ b/app/package.json
@@ -48,6 +48,7 @@
     "expo-linking": "~8.0.12",
     "expo-localization": "~17.0.8",
     "expo-screen-orientation": "~9.0.9",
+    "expo-secure-store": "~15.0.8",
     "jest": "~29.7.0",
     "jest-expo": "~54.0.17",
     "lodash": "^4.17.21",

--- a/app/package.json
+++ b/app/package.json
@@ -85,6 +85,7 @@
     "@eslint/js": "^9.5.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/react-native": "^13.0.1",
+    "@types/crypto-js": "^4.2.2",
     "@types/redux-mock-store": "^1.5.0",
     "eslint": "9.x",
     "eslint-plugin-react": "^7.34.2",

--- a/app/src/components/LanguageSelector.tsx
+++ b/app/src/components/LanguageSelector.tsx
@@ -8,6 +8,9 @@ import { useDispatch } from 'react-redux'
 import { setLocale } from '../redux/actions'
 import { WheelPickerOption } from './WheelPicker'
 import { analytics } from '../services/firebase'
+import { getActiveBundle } from '../redux/storeManager'
+import { ANON_USER_ID } from '../services/storage/storageKeys'
+import { setPendingLocale } from '../services/auth/pendingLocale'
 
 export const LanguageSelector = (props: ButtonProps) => {
   const locale = useSelector(currentLocaleSelector)
@@ -19,6 +22,13 @@ export const LanguageSelector = (props: ButtonProps) => {
     }
 
     dispatch(setLocale(option.value))
+
+    // When picked on the logged-out auth screen (anon store), remember it as an explicit choice so
+    // it carries into the account the user logs into next instead of being overridden by that
+    // account's saved language.
+    if (getActiveBundle()?.userId === ANON_USER_ID) {
+      setPendingLocale(option.value)
+    }
 
     analytics?.().logEvent('languageChanged', {
       selectedLanguage: option.value,

--- a/app/src/core/types/translations/app.ts
+++ b/app/src/core/types/translations/app.ts
@@ -275,6 +275,7 @@ export interface AppTranslations {
   mood: string
   music: string
   name: string
+  max_accounts_reached: string
   name_info_label: string
   name_input: string
   name_taken_error: string

--- a/app/src/redux/StoreManagerContext.tsx
+++ b/app/src/redux/StoreManagerContext.tsx
@@ -1,0 +1,40 @@
+// Boots the store manager (after running the one-time legacy migration) and hands the active
+// per-user store/persistor to the app via a render prop, re-rendering whenever the active
+// user switches so PersistGate remounts cleanly on the new user's key.
+import * as React from 'react'
+import { getActiveBundle, initStoreManager, subscribeBundle, StoreBundle } from './storeManager'
+import { runLegacyMigration } from '../services/migration/legacyMigration'
+
+export function StoreManagerProvider({
+  children,
+}: {
+  children: (bundle: StoreBundle) => React.ReactNode
+}) {
+  const [bundle, setBundle] = React.useState<StoreBundle | null>(getActiveBundle())
+
+  React.useEffect(() => {
+    let mounted = true
+    const unsubscribe = subscribeBundle((next) => {
+      if (mounted) {
+        setBundle(next)
+      }
+    })
+    void (async () => {
+      // Migration MUST complete before the store is built for the active user.
+      await runLegacyMigration()
+      const built = await initStoreManager()
+      if (mounted) {
+        setBundle(built)
+      }
+    })()
+    return () => {
+      mounted = false
+      unsubscribe()
+    }
+  }, [])
+
+  if (!bundle) {
+    return null
+  }
+  return <>{children(bundle)}</>
+}

--- a/app/src/redux/actions/appActions.ts
+++ b/app/src/redux/actions/appActions.ts
@@ -47,6 +47,10 @@ export function setHasOpened(hasOpened: boolean) {
   return createAction('SET_HAS_OPENED', { hasOpened })
 }
 
+export function setOnboardingPending(onboardingPending: boolean) {
+  return createAction('SET_ONBOARDING_PENDING', { onboardingPending })
+}
+
 export function setTutorialOneActive(isTutorialActive: boolean) {
   return createAction('SET_TUTORIAL_ONE_ACTIVE', { isTutorialActive })
 }

--- a/app/src/redux/reducers/appReducer.ts
+++ b/app/src/redux/reducers/appReducer.ts
@@ -15,6 +15,10 @@ export interface AppState {
   appVersionCode: string
   firebaseToken: string
   hasOpened: boolean
+  // True between creating an account and finishing its onboarding (avatar/theme/period survey).
+  // Drives the auth screen into the onboarding flow for the new account's store, and survives the
+  // store-switch remount that signup performs.
+  onboardingPending: boolean
   isTutorialOneActive: boolean
   isTutorialTwoActive: boolean
   isCustomAvatarTutorialActive: boolean
@@ -46,6 +50,7 @@ const initialState: AppState = {
   firebaseToken: null,
   locale: initialLocale,
   hasOpened: false,
+  onboardingPending: false,
   isTutorialOneActive: true,
   isTutorialTwoActive: true,
   isCustomAvatarTutorialActive: true,
@@ -111,6 +116,11 @@ export function appReducer(state = initialState, action: Actions | RehydrateActi
       return {
         ...state,
         hasOpened: action.payload.hasOpened,
+      }
+    case 'SET_ONBOARDING_PENDING':
+      return {
+        ...state,
+        onboardingPending: action.payload.onboardingPending,
       }
     case 'SET_TUTORIAL_ONE_ACTIVE':
       return {

--- a/app/src/redux/sagas/analyticsSaga.ts
+++ b/app/src/redux/sagas/analyticsSaga.ts
@@ -1,4 +1,4 @@
-import { all, delay, fork, put, select, takeLatest } from 'redux-saga/effects'
+import { all, call, delay, fork, put, select, takeLatest } from 'redux-saga/effects'
 import { v4 as uuidv4 } from 'uuid'
 import moment from 'moment'
 import { httpClient } from '../../services/HttpClient'
@@ -6,6 +6,7 @@ import * as actions from '../actions'
 import * as selectors from '../selectors'
 import { ActionTypes } from '../types'
 import { fetchNetworkConnectionStatus } from '../../services/network'
+import { getDeviceId } from '../../services/deviceId'
 
 const ACTIONS_TO_TRACK: ActionTypes[] = [
   // app
@@ -30,8 +31,10 @@ const ACTIONS_TO_TRACK: ActionTypes[] = [
 function* onTrackAction(action) {
   // @ts-expect-error TODO:
   const currentUser = yield select(selectors.currentUserSelector)
+  // Use the canonical install-stable device id (AsyncStorage-backed), not the per-account redux
+  // app.deviceId, which is regenerated per store and would tag one device as many.
   // @ts-expect-error TODO:
-  const deviceId = yield select(selectors.currentDeviceId)
+  const deviceId = yield call(getDeviceId)
   yield put(
     actions.queueEvent({
       id: uuidv4(),

--- a/app/src/redux/selectors/appSelectors.ts
+++ b/app/src/redux/selectors/appSelectors.ts
@@ -19,6 +19,8 @@ export const currentAvatarSelector = (state: ReduxState) => s(state).avatar
 
 export const hasOpenedSelector = (state: ReduxState) => s(state).hasOpened
 
+export const onboardingPendingSelector = (state: ReduxState) => s(state).onboardingPending
+
 export const isTutorialOneActiveSelector = (state: ReduxState) => s(state).isTutorialOneActive
 
 export const isTutorialTwoActiveSelector = (state: ReduxState) => s(state).isTutorialTwoActive

--- a/app/src/redux/storeManager.ts
+++ b/app/src/redux/storeManager.ts
@@ -34,7 +34,7 @@ let active: StoreBundle | null = null
 let activeSaga: Task | null = null
 const listeners = new Set<(bundle: StoreBundle) => void>()
 
-function buildBundle(userId: string): StoreBundle {
+function buildBundle(userId: string): Promise<StoreBundle> {
   const persistConfig = {
     version: reduxStoreVersion,
     key: userDataConfigKey(userId),
@@ -53,9 +53,14 @@ function buildBundle(userId: string): StoreBundle {
   // @ts-ignore redux-persist reducer typing
   const store = createStore(persistedReducer, applyMiddleware(sagaMiddleware))
   activeSaga = sagaMiddleware.run(rootSaga)
-  const persistor = persistStore(store)
   setHttpClientStore(store as Parameters<typeof setHttpClientStore>[0])
-  return { userId, store, persistor }
+  // Resolve only after rehydration finishes, so callers (e.g. signup) can dispatch into the
+  // store without a late REHYDRATE overwriting what they dispatched.
+  return new Promise<StoreBundle>((resolve) => {
+    const persistor = persistStore(store, null, () => {
+      resolve({ userId, store, persistor })
+    })
+  })
 }
 
 export function getActiveBundle(): StoreBundle | null {
@@ -100,7 +105,7 @@ export async function initStoreManager(): Promise<StoreBundle> {
     getActiveUserId: () => Promise<string | null>
   }
   const userId = (await getActiveUserId()) || ANON_USER_ID
-  active = buildBundle(userId)
+  active = await buildBundle(userId)
   notify(active)
   return active
 }
@@ -117,7 +122,7 @@ export async function switchToUser(userId: string): Promise<StoreBundle> {
     }
     await setActiveUser(userId)
   }
-  active = buildBundle(userId)
+  active = await buildBundle(userId)
   notify(active)
   return active
 }

--- a/app/src/redux/storeManager.ts
+++ b/app/src/redux/storeManager.ts
@@ -1,6 +1,12 @@
 // Per-user redux store manager. Replaces the old single static store. Each user gets their
 // own redux-persist store keyed 'user:{id}:data', so accounts never share or overwrite state.
 // Switching tears down the active store (after flushing it) and builds the selected user's.
+//
+// All transitions (init / switch / purge) are serialized through a single promise chain so that
+// concurrent account operations (e.g. a double-tap on the switcher, or a logout firing during a
+// signup) can never interleave and corrupt the module state or write one account's data into
+// another's store. Each bundle also owns its own saga task, so an overlapping build can never
+// orphan a still-running saga.
 import { applyMiddleware, createStore, Store } from 'redux'
 import { persistStore, persistReducer, PersistedState, Persistor } from 'redux-persist'
 import AsyncStorage from '@react-native-async-storage/async-storage'
@@ -10,7 +16,7 @@ import { rootReducer } from './reducers'
 import { rootSaga } from './sagas'
 import { reduxMigrations, reduxStoreVersion } from '../optional/reduxMigrations'
 import { setHttpClientStore } from '../services/HttpClient'
-import { getEncryptionKey } from '../services/auth/encryptionKeys'
+import { getEncryptionKey, EncryptionKeyUnavailableError } from '../services/auth/encryptionKeys'
 import {
   userDataConfigKey,
   userDataStorageKey,
@@ -21,19 +27,35 @@ export interface StoreBundle {
   userId: string
   store: Store
   persistor: Persistor
+  // The saga task for this bundle's store, owned by the bundle so it is always the one cancelled
+  // on teardown (never overwritten by an overlapping build).
+  saga: Task
 }
 
 let active: StoreBundle | null = null
-let activeSaga: Task | null = null
 const listeners = new Set<(bundle: StoreBundle) => void>()
+
+// Serialize every store-manager transition. enqueue runs fn only after the previous transition
+// has fully settled, so `active` is never mutated by two transitions at once.
+let opChain: Promise<unknown> = Promise.resolve()
+function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+  const run = opChain.then(fn, fn)
+  opChain = run.then(
+    () => undefined,
+    () => undefined,
+  )
+  return run
+}
 
 async function buildBundle(userId: string): Promise<StoreBundle> {
   // Per-account encryptor: keyed by this account's Keychain key (or the global key for legacy
-  // accounts), so accounts never share an encryption key.
+  // accounts). Resolving the key first means a key-unavailable error aborts the build BEFORE any
+  // store/persistor exists, so a wrong-key store can never be created and then overwrite the blob.
+  const secretKey = await getEncryptionKey(userId)
   const encryptor = encryptTransform({
-    secretKey: await getEncryptionKey(userId),
+    secretKey,
     onError: function () {
-      // @TODO: handle decryption errors
+      // @TODO: surface decryption errors
     },
   })
   const persistConfig = {
@@ -53,15 +75,29 @@ async function buildBundle(userId: string): Promise<StoreBundle> {
   const sagaMiddleware = createSagaMiddleware()
   // @ts-ignore redux-persist reducer typing
   const store = createStore(persistedReducer, applyMiddleware(sagaMiddleware))
-  activeSaga = sagaMiddleware.run(rootSaga)
+  const saga = sagaMiddleware.run(rootSaga)
   setHttpClientStore(store as Parameters<typeof setHttpClientStore>[0])
   // Resolve only after rehydration finishes, so callers (e.g. signup) can dispatch into the
   // store without a late REHYDRATE overwriting what they dispatched.
   return new Promise<StoreBundle>((resolve) => {
     const persistor = persistStore(store, null, () => {
-      resolve({ userId, store, persistor })
+      resolve({ userId, store, persistor, saga })
     })
   })
+}
+
+// Build the requested user's bundle, falling back to a fresh anon bundle if that account's
+// encryption key cannot be read right now (a transient Keychain failure). The fallback never
+// touches the account's persisted blob, so the data stays intact for a later successful open.
+async function buildBundleSafe(userId: string): Promise<StoreBundle> {
+  try {
+    return await buildBundle(userId)
+  } catch (err) {
+    if (err instanceof EncryptionKeyUnavailableError && userId !== ANON_USER_ID) {
+      return buildBundle(ANON_USER_ID)
+    }
+    throw err
+  }
 }
 
 export function getActiveBundle(): StoreBundle | null {
@@ -83,60 +119,64 @@ async function teardownActive(): Promise<void> {
   if (!active) {
     return
   }
+  const bundle = active
+  active = null
   try {
-    await active.persistor.flush()
+    await bundle.persistor.flush()
   } catch {
     // ignore flush errors during teardown
   }
-  if (activeSaga) {
-    activeSaga.cancel()
-    activeSaga = null
-  }
-  active = null
+  bundle.saga.cancel()
 }
 
 // Build the store for whoever the registry says is active (or an empty anon store on a
-// fresh device). Idempotent: returns the existing bundle if already built.
-export async function initStoreManager(): Promise<StoreBundle> {
-  if (active) {
+// fresh device). Idempotent: returns the existing bundle if already built. Serialized.
+export function initStoreManager(): Promise<StoreBundle> {
+  return enqueue(async () => {
+    if (active) {
+      return active
+    }
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getActiveUserId } = require('../services/userMetadata/registry') as {
+      getActiveUserId: () => Promise<string | null>
+    }
+    const userId = (await getActiveUserId()) || ANON_USER_ID
+    active = await buildBundleSafe(userId)
+    notify(active)
     return active
-  }
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { getActiveUserId } = require('../services/userMetadata/registry') as {
-    getActiveUserId: () => Promise<string | null>
-  }
-  const userId = (await getActiveUserId()) || ANON_USER_ID
-  active = await buildBundle(userId)
-  notify(active)
-  return active
+  })
 }
 
-export async function switchToUser(userId: string): Promise<StoreBundle> {
-  if (active && active.userId === userId) {
-    return active
-  }
-  await teardownActive()
-  if (userId !== ANON_USER_ID) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { setActiveUser } = require('../services/userMetadata/registry') as {
-      setActiveUser: (id: string | null) => Promise<void>
+export function switchToUser(userId: string): Promise<StoreBundle> {
+  return enqueue(async () => {
+    if (active && active.userId === userId) {
+      return active
     }
-    await setActiveUser(userId)
-  }
-  active = await buildBundle(userId)
-  notify(active)
-  return active
+    await teardownActive()
+    if (userId !== ANON_USER_ID) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { setActiveUser } = require('../services/userMetadata/registry') as {
+        setActiveUser: (id: string | null) => Promise<void>
+      }
+      await setActiveUser(userId)
+    }
+    active = await buildBundleSafe(userId)
+    notify(active)
+    return active
+  })
 }
 
 // Delete a user's persisted store blob. Tears down the active store first if it belongs to
 // that user. Called by registry.removeUser (lazy-required there to avoid an import cycle).
-export async function purgeUserStorage(userId: string): Promise<void> {
-  if (active && active.userId === userId) {
-    await teardownActive()
-  }
-  try {
-    await AsyncStorage.removeItem(userDataStorageKey(userId))
-  } catch {
-    // already gone
-  }
+export function purgeUserStorage(userId: string): Promise<void> {
+  return enqueue(async () => {
+    if (active && active.userId === userId) {
+      await teardownActive()
+    }
+    try {
+      await AsyncStorage.removeItem(userDataStorageKey(userId))
+    } catch {
+      // already gone
+    }
+  })
 }

--- a/app/src/redux/storeManager.ts
+++ b/app/src/redux/storeManager.ts
@@ -8,9 +8,9 @@ import { encryptTransform } from 'redux-persist-transform-encrypt'
 import createSagaMiddleware, { Task } from 'redux-saga'
 import { rootReducer } from './reducers'
 import { rootSaga } from './sagas'
-import { config } from '../resources/redux'
 import { reduxMigrations, reduxStoreVersion } from '../optional/reduxMigrations'
 import { setHttpClientStore } from '../services/HttpClient'
+import { getEncryptionKey } from '../services/auth/encryptionKeys'
 import {
   userDataConfigKey,
   userDataStorageKey,
@@ -23,18 +23,19 @@ export interface StoreBundle {
   persistor: Persistor
 }
 
-const encryptor = encryptTransform({
-  secretKey: config.REDUX_ENCRYPT_KEY,
-  onError: function () {
-    // @TODO: handle decryption errors
-  },
-})
-
 let active: StoreBundle | null = null
 let activeSaga: Task | null = null
 const listeners = new Set<(bundle: StoreBundle) => void>()
 
-function buildBundle(userId: string): Promise<StoreBundle> {
+async function buildBundle(userId: string): Promise<StoreBundle> {
+  // Per-account encryptor: keyed by this account's Keychain key (or the global key for legacy
+  // accounts), so accounts never share an encryption key.
+  const encryptor = encryptTransform({
+    secretKey: await getEncryptionKey(userId),
+    onError: function () {
+      // @TODO: handle decryption errors
+    },
+  })
   const persistConfig = {
     version: reduxStoreVersion,
     key: userDataConfigKey(userId),

--- a/app/src/redux/storeManager.ts
+++ b/app/src/redux/storeManager.ts
@@ -1,0 +1,136 @@
+// Per-user redux store manager. Replaces the old single static store. Each user gets their
+// own redux-persist store keyed 'user:{id}:data', so accounts never share or overwrite state.
+// Switching tears down the active store (after flushing it) and builds the selected user's.
+import { applyMiddleware, createStore, Store } from 'redux'
+import { persistStore, persistReducer, PersistedState, Persistor } from 'redux-persist'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { encryptTransform } from 'redux-persist-transform-encrypt'
+import createSagaMiddleware, { Task } from 'redux-saga'
+import { rootReducer } from './reducers'
+import { rootSaga } from './sagas'
+import { config } from '../resources/redux'
+import { reduxMigrations, reduxStoreVersion } from '../optional/reduxMigrations'
+import { setHttpClientStore } from '../services/HttpClient'
+import {
+  userDataConfigKey,
+  userDataStorageKey,
+  ANON_USER_ID,
+} from '../services/storage/storageKeys'
+
+export interface StoreBundle {
+  userId: string
+  store: Store
+  persistor: Persistor
+}
+
+const encryptor = encryptTransform({
+  secretKey: config.REDUX_ENCRYPT_KEY,
+  onError: function () {
+    // @TODO: handle decryption errors
+  },
+})
+
+let active: StoreBundle | null = null
+let activeSaga: Task | null = null
+const listeners = new Set<(bundle: StoreBundle) => void>()
+
+function buildBundle(userId: string): StoreBundle {
+  const persistConfig = {
+    version: reduxStoreVersion,
+    key: userDataConfigKey(userId),
+    storage: AsyncStorage,
+    transforms: [encryptor],
+    migrate: (state: PersistedState) => {
+      if (reduxMigrations[reduxStoreVersion]) {
+        return Promise.resolve(reduxMigrations[reduxStoreVersion]?.(state, reduxStoreVersion))
+      }
+      return Promise.resolve(state)
+    },
+  }
+  // @ts-ignore redux-persist reducer typing
+  const persistedReducer = persistReducer(persistConfig, rootReducer)
+  const sagaMiddleware = createSagaMiddleware()
+  // @ts-ignore redux-persist reducer typing
+  const store = createStore(persistedReducer, applyMiddleware(sagaMiddleware))
+  activeSaga = sagaMiddleware.run(rootSaga)
+  const persistor = persistStore(store)
+  setHttpClientStore(store as Parameters<typeof setHttpClientStore>[0])
+  return { userId, store, persistor }
+}
+
+export function getActiveBundle(): StoreBundle | null {
+  return active
+}
+
+export function subscribeBundle(fn: (bundle: StoreBundle) => void): () => void {
+  listeners.add(fn)
+  return () => {
+    listeners.delete(fn)
+  }
+}
+
+function notify(bundle: StoreBundle): void {
+  listeners.forEach((l) => l(bundle))
+}
+
+async function teardownActive(): Promise<void> {
+  if (!active) {
+    return
+  }
+  try {
+    await active.persistor.flush()
+  } catch {
+    // ignore flush errors during teardown
+  }
+  if (activeSaga) {
+    activeSaga.cancel()
+    activeSaga = null
+  }
+  active = null
+}
+
+// Build the store for whoever the registry says is active (or an empty anon store on a
+// fresh device). Idempotent: returns the existing bundle if already built.
+export async function initStoreManager(): Promise<StoreBundle> {
+  if (active) {
+    return active
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { getActiveUserId } = require('../services/userMetadata/registry') as {
+    getActiveUserId: () => Promise<string | null>
+  }
+  const userId = (await getActiveUserId()) || ANON_USER_ID
+  active = buildBundle(userId)
+  notify(active)
+  return active
+}
+
+export async function switchToUser(userId: string): Promise<StoreBundle> {
+  if (active && active.userId === userId) {
+    return active
+  }
+  await teardownActive()
+  if (userId !== ANON_USER_ID) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { setActiveUser } = require('../services/userMetadata/registry') as {
+      setActiveUser: (id: string | null) => Promise<void>
+    }
+    await setActiveUser(userId)
+  }
+  active = buildBundle(userId)
+  notify(active)
+  return active
+}
+
+// Delete a user's persisted store blob. Tears down the active store first if it belongs to
+// that user. Called by registry.removeUser (lazy-required there to avoid an import cycle).
+export async function purgeUserStorage(userId: string): Promise<void> {
+  if (active && active.userId === userId) {
+    await teardownActive()
+  }
+  try {
+    await AsyncStorage.removeItem(userDataStorageKey(userId))
+  } catch {
+    // already gone
+  }
+}

--- a/app/src/screens/AuthScreen/AuthModeContext.tsx
+++ b/app/src/screens/AuthScreen/AuthModeContext.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { useSelector } from '../../redux/useSelector'
-import { currentUserSelector, hasOpenedSelector } from '../../redux/selectors'
+import {
+  currentUserSelector,
+  hasOpenedSelector,
+  onboardingPendingSelector,
+} from '../../redux/selectors'
 import { listUsers } from '../../services/userMetadata/registry'
 
 export type AuthMode =
@@ -31,6 +35,8 @@ const AuthContext = React.createContext<AuthModeContext>(defaultValue)
 export const AuthModeProvider = ({ children }: React.PropsWithChildren) => {
   const user = useSelector(currentUserSelector)
   const hasOpened = useSelector(hasOpenedSelector)
+  // Set on the just-created account's store by signupAccount; routes straight into onboarding.
+  const onboardingPending = useSelector(onboardingPendingSelector)
 
   // hasOpened lives in the per-user (and anon) redux store, so after a logout the fresh anon
   // store would replay the one-time welcome intro. Gate the intro on the device having no
@@ -61,18 +67,33 @@ export const AuthModeProvider = ({ children }: React.PropsWithChildren) => {
   }
 
   return (
-    <AuthModeInner showWelcome={!hasOpened && !hasAccounts} hasUser={!!user}>
+    <AuthModeInner
+      onboardingPending={!!onboardingPending}
+      showWelcome={!hasOpened && !hasAccounts}
+      hasUser={!!user}
+    >
       {children}
     </AuthModeInner>
   )
 }
 
 const AuthModeInner = ({
+  onboardingPending,
   showWelcome,
   hasUser,
   children,
-}: React.PropsWithChildren<{ showWelcome: boolean; hasUser: boolean }>) => {
-  const initialState: AuthMode = showWelcome ? 'welcome' : hasUser ? 'log_in' : 'start'
+}: React.PropsWithChildren<{
+  onboardingPending: boolean
+  showWelcome: boolean
+  hasUser: boolean
+}>) => {
+  const initialState: AuthMode = onboardingPending
+    ? 'avatar_selection'
+    : showWelcome
+    ? 'welcome'
+    : hasUser
+    ? 'log_in'
+    : 'start'
   const [authMode, setAuthMode] = React.useState<AuthMode>(initialState)
 
   return <AuthContext.Provider value={{ authMode, setAuthMode }}>{children}</AuthContext.Provider>

--- a/app/src/screens/AuthScreen/AuthModeContext.tsx
+++ b/app/src/screens/AuthScreen/AuthModeContext.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSelector } from '../../redux/useSelector'
 import { currentUserSelector, hasOpenedSelector } from '../../redux/selectors'
+import { listUsers } from '../../services/userMetadata/registry'
 
 export type AuthMode =
   | 'welcome'
@@ -31,7 +32,47 @@ export const AuthModeProvider = ({ children }: React.PropsWithChildren) => {
   const user = useSelector(currentUserSelector)
   const hasOpened = useSelector(hasOpenedSelector)
 
-  const initialState = !hasOpened ? 'welcome' : user ? 'log_in' : 'start'
+  // hasOpened lives in the per-user (and anon) redux store, so after a logout the fresh anon
+  // store would replay the one-time welcome intro. Gate the intro on the device having no
+  // accounts yet, so it only ever shows on a genuinely fresh device.
+  const [hasAccounts, setHasAccounts] = React.useState<boolean | null>(null)
+  React.useEffect(() => {
+    let mounted = true
+    listUsers()
+      .then((accounts) => {
+        if (mounted) {
+          setHasAccounts(accounts.length > 0)
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setHasAccounts(false)
+        }
+      })
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  // Wait for the account check before deciding the initial mode, so the welcome intro never
+  // flashes on a device that already has accounts.
+  if (hasAccounts === null) {
+    return null
+  }
+
+  return (
+    <AuthModeInner showWelcome={!hasOpened && !hasAccounts} hasUser={!!user}>
+      {children}
+    </AuthModeInner>
+  )
+}
+
+const AuthModeInner = ({
+  showWelcome,
+  hasUser,
+  children,
+}: React.PropsWithChildren<{ showWelcome: boolean; hasUser: boolean }>) => {
+  const initialState: AuthMode = showWelcome ? 'welcome' : hasUser ? 'log_in' : 'start'
   const [authMode, setAuthMode] = React.useState<AuthMode>(initialState)
 
   return <AuthContext.Provider value={{ authMode, setAuthMode }}>{children}</AuthContext.Provider>

--- a/app/src/screens/AuthScreen/components/AccountSwitcher.tsx
+++ b/app/src/screens/AuthScreen/components/AccountSwitcher.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { StyleSheet, TouchableOpacity } from 'react-native'
+import FontAwesome from '@expo/vector-icons/FontAwesome'
+import { WheelPickerModal } from '../../../components/WheelPickerModal'
+import { WheelPickerOption } from '../../../components/WheelPicker'
+import { Text } from '../../../components/Text'
+import { AuthCardBody } from './AuthCardBody'
+import { useColor } from '../../../hooks/useColor'
+import { listAccounts, switchToAccount } from '../../../services/auth/accountFlows'
+
+// The dropdown trigger: looks like the app's input boxes (rounded, filled) with a chevron, so it
+// reads as a dropdown. Renders "Select a user" directly to avoid the translate fallback.
+const SelectUserToggle: React.FC<{ onPress: () => void }> = ({ onPress }) => {
+  const { inputBackgroundColor, placeholderTextColor, color } = useColor()
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.8}
+      style={[styles.toggle, { backgroundColor: inputBackgroundColor }]}
+    >
+      <Text enableTranslate={false} style={[styles.toggleText, { color: placeholderTextColor }]}>
+        Select a user
+      </Text>
+      <FontAwesome name="chevron-down" size={16} color={color} />
+    </TouchableOpacity>
+  )
+}
+
+// Dropdown of the accounts registered on this device. Selecting one switches the active store to
+// that account, after which the auth flow shows its passcode screen. Shown on the logged-out
+// start screen; renders nothing when there are no saved accounts.
+export const AccountSwitcher = () => {
+  const [options, setOptions] = React.useState<WheelPickerOption[]>([])
+
+  React.useEffect(() => {
+    let mounted = true
+    listAccounts().then((list) => {
+      if (mounted) {
+        setOptions(list.map((account) => ({ label: account.name, value: account.id })))
+      }
+    })
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  if (options.length === 0) {
+    return null
+  }
+
+  const onSelect = (option?: WheelPickerOption) => {
+    if (option) {
+      void switchToAccount(option.value)
+    }
+  }
+
+  return (
+    <AuthCardBody>
+      <WheelPickerModal
+        initialOption={options[0]}
+        options={options}
+        onSelect={onSelect}
+        allowUndefined={false}
+        ToggleComponent={SelectUserToggle}
+      />
+    </AuthCardBody>
+  )
+}
+
+const styles = StyleSheet.create({
+  toggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: 20,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+  },
+  toggleText: {
+    fontSize: 16,
+  },
+})

--- a/app/src/screens/AuthScreen/components/AccountSwitcher.tsx
+++ b/app/src/screens/AuthScreen/components/AccountSwitcher.tsx
@@ -7,6 +7,9 @@ import { Text } from '../../../components/Text'
 import { AuthCardBody } from './AuthCardBody'
 import { useColor } from '../../../hooks/useColor'
 import { listAccounts, switchToAccount } from '../../../services/auth/accountFlows'
+import { useSelector } from '../../../redux/useSelector'
+import { currentUserSelector } from '../../../redux/selectors'
+import { useAuthMode } from '../AuthModeContext'
 
 // The dropdown trigger: looks like the app's input boxes (rounded, filled) with a chevron, so it
 // reads as a dropdown. Renders "Select a user" directly to avoid the translate fallback.
@@ -31,6 +34,8 @@ const SelectUserToggle: React.FC<{ onPress: () => void }> = ({ onPress }) => {
 // start screen; renders nothing when there are no saved accounts.
 export const AccountSwitcher = () => {
   const [options, setOptions] = React.useState<WheelPickerOption[]>([])
+  const currentUser = useSelector(currentUserSelector)
+  const { setAuthMode } = useAuthMode()
 
   React.useEffect(() => {
     let mounted = true
@@ -49,9 +54,16 @@ export const AccountSwitcher = () => {
   }
 
   const onSelect = (option?: WheelPickerOption) => {
-    if (option) {
-      void switchToAccount(option.value)
+    if (!option) {
+      return
     }
+    // If the chosen account is already the one loaded in the active store, switchToUser would
+    // short-circuit (no remount) and nothing would happen. Show its passcode screen directly.
+    if (currentUser && option.value === currentUser.id) {
+      setAuthMode('log_in')
+      return
+    }
+    void switchToAccount(option.value)
   }
 
   return (

--- a/app/src/screens/AuthScreen/components/AuthHeader.tsx
+++ b/app/src/screens/AuthScreen/components/AuthHeader.tsx
@@ -3,22 +3,22 @@ import { StyleSheet, View } from 'react-native'
 import FontAwesome from '@expo/vector-icons/FontAwesome'
 import { Button } from '../../../components/Button'
 import { useAuthMode } from '../AuthModeContext'
-import { useDispatch } from 'react-redux'
 import { useSelector } from '../../../redux/useSelector'
 import { currentUserSelector } from '../../../redux/selectors'
-import { logoutRequest } from '../../../redux/actions'
+import { logoutToAnon } from '../../../services/auth/accountFlows'
 import { Text } from '../../../components/Text'
 import { useColor } from '../../../hooks/useColor'
 
 export const AuthHeader = ({ title }: { title: string }) => {
   const user = useSelector(currentUserSelector)
-  const dispatch = useDispatch()
   const { setAuthMode } = useAuthMode()
   const { palette } = useColor()
 
   const onClose = () => {
     if (user) {
-      dispatch(logoutRequest())
+      // Leave this account for the logged-out (anon) context without wiping its saved data.
+      void logoutToAnon()
+      return
     }
 
     setAuthMode('start')

--- a/app/src/screens/AuthScreen/components/AuthHeader.tsx
+++ b/app/src/screens/AuthScreen/components/AuthHeader.tsx
@@ -3,24 +3,21 @@ import { StyleSheet, View } from 'react-native'
 import FontAwesome from '@expo/vector-icons/FontAwesome'
 import { Button } from '../../../components/Button'
 import { useAuthMode } from '../AuthModeContext'
-import { useSelector } from '../../../redux/useSelector'
-import { currentUserSelector } from '../../../redux/selectors'
 import { logoutToAnon } from '../../../services/auth/accountFlows'
 import { Text } from '../../../components/Text'
 import { useColor } from '../../../hooks/useColor'
 
 export const AuthHeader = ({ title }: { title: string }) => {
-  const user = useSelector(currentUserSelector)
   const { setAuthMode } = useAuthMode()
   const { palette } = useColor()
 
+  // Return to the account-selection / login-signup start screen in a genuinely logged-out state.
+  // Switching to the anon store clears the loaded account, so the login form is empty/editable
+  // (its name field is locked while an account is loaded) and the switcher lists every account.
+  // setAuthMode('start') is synchronous insurance for the case where the store switch is a no-op
+  // (already anon) and so does not remount the screen.
   const onClose = () => {
-    if (user) {
-      // Leave this account for the logged-out (anon) context without wiping its saved data.
-      void logoutToAnon()
-      return
-    }
-
+    void logoutToAnon()
     setAuthMode('start')
   }
 

--- a/app/src/screens/AuthScreen/components/DeleteAccount.tsx
+++ b/app/src/screens/AuthScreen/components/DeleteAccount.tsx
@@ -6,6 +6,7 @@ import { Input } from '../../../components/Input'
 import { Text } from '../../../components/Text'
 import { httpClient } from '../../../services/HttpClient'
 import { formatPassword } from '../../../services/auth'
+import { deleteAccountByPassword } from '../../../services/auth/accountFlows'
 import { useTranslate } from '../../../hooks/useTranslate'
 import { useAuthMode } from '../AuthModeContext'
 import { AuthCardBody } from './AuthCardBody'
@@ -32,14 +33,16 @@ export const DeleteAccount = () => {
     }
 
     try {
-      // Check user exists
-      await httpClient.getUserInfo(name)
+      // Delete a locally registered account first (works offline), then fall back to the server.
+      const deletedLocally = await deleteAccountByPassword(name, formatPassword(password))
 
-      // Delete
-      await httpClient.deleteUserFromPassword({
-        name,
-        password: formatPassword(password),
-      })
+      if (!deletedLocally) {
+        await httpClient.getUserInfo(name)
+        await httpClient.deleteUserFromPassword({
+          name,
+          password: formatPassword(password),
+        })
+      }
 
       Alert.alert('success', 'delete_account_completed', [
         {

--- a/app/src/screens/AuthScreen/components/ForgotPassword.tsx
+++ b/app/src/screens/AuthScreen/components/ForgotPassword.tsx
@@ -6,6 +6,7 @@ import { Input } from '../../../components/Input'
 import { Text } from '../../../components/Text'
 import { httpClient } from '../../../services/HttpClient'
 import { formatPassword } from '../../../services/auth'
+import { resetPasswordOffline } from '../../../services/auth/accountFlows'
 import { useTranslate } from '../../../hooks/useTranslate'
 import { useAuthMode } from '../AuthModeContext'
 import { AuthCardBody } from './AuthCardBody'
@@ -64,15 +65,22 @@ export const ForgotPassword = () => {
     }
 
     try {
-      // Check exists
-      await httpClient.getUserInfo(name)
-
-      // Reset
-      await httpClient.resetPassword({
+      // Try a locally registered account first (works offline via the secret answer).
+      const resetLocally = await resetPasswordOffline(
         name,
-        secretAnswer: formatPassword(answer),
-        password: formatPassword(password),
-      })
+        formatPassword(answer),
+        formatPassword(password),
+      )
+
+      if (!resetLocally) {
+        // No local account with this name: reset on the server instead.
+        await httpClient.getUserInfo(name)
+        await httpClient.resetPassword({
+          name,
+          secretAnswer: formatPassword(answer),
+          password: formatPassword(password),
+        })
+      }
 
       successAlert()
     } catch (e) {

--- a/app/src/screens/AuthScreen/components/Journey/components/JourneyReview.tsx
+++ b/app/src/screens/AuthScreen/components/Journey/components/JourneyReview.tsx
@@ -7,7 +7,7 @@ import { journeyConfig } from '../journeyConfig'
 import { DisplayButton } from '../../../../../components/Button'
 import { useDispatch } from 'react-redux'
 import moment from 'moment'
-import { journeyCompletion } from '../../../../../redux/actions'
+import { journeyCompletion, setOnboardingPending } from '../../../../../redux/actions'
 import { useAuth } from '../../../../../contexts/AuthContext'
 import { Text } from '../../../../../components/Text'
 import { useColor } from '../../../../../hooks/useColor'
@@ -42,7 +42,9 @@ export const JourneyReview = () => {
 
     reduxDispatch(journeyCompletion(answers))
 
-    // TODO: wait for success
+    // Onboarding is complete: clear the pending flag (so a later login doesn't re-enter the
+    // onboarding flow) and enter the app.
+    reduxDispatch(setOnboardingPending(false))
     setIsLoggedIn(true)
   }
 

--- a/app/src/screens/AuthScreen/components/LogIn.tsx
+++ b/app/src/screens/AuthScreen/components/LogIn.tsx
@@ -32,6 +32,23 @@ export const LogIn = () => {
 
   const [margin, setMargin] = React.useState(0)
 
+  // The online login path resolves in the saga (loginFailure increments this), so surface its
+  // failures here too — otherwise a wrong password / network error for a server-only account
+  // (e.g. after a reinstall) gives no feedback at all.
+  const loginFailedCount = useSelector((state) => state.auth.loginFailedCount)
+  const prevFailedCount = React.useRef(loginFailedCount)
+  React.useEffect(() => {
+    if (loginFailedCount > prevFailedCount.current) {
+      setSuccess(false)
+    }
+    prevFailedCount.current = loginFailedCount
+  }, [loginFailedCount])
+
+  // Clear a stale "incorrect" message as soon as the user edits either field.
+  React.useEffect(() => {
+    setSuccess(null)
+  }, [name, password])
+
   // Pre-fill username from pending sync data after a forced logout
   React.useEffect(() => {
     if (user || name) return

--- a/app/src/screens/AuthScreen/components/LogIn.tsx
+++ b/app/src/screens/AuthScreen/components/LogIn.tsx
@@ -13,6 +13,7 @@ import { loginRequest } from '../../../redux/actions'
 import { Text } from '../../../components/Text'
 import { AuthCardBody } from './AuthCardBody'
 import { loadPendingSyncData } from '../../../services/pendingSync'
+import { loginToAccount } from '../../../services/auth/accountFlows'
 
 export const LogIn = () => {
   const user = useSelector(currentUserSelector)
@@ -40,26 +41,36 @@ export const LogIn = () => {
     })
   }, [])
 
-  const onConfirm = () => {
+  const onConfirm = async () => {
     if (errors.length) {
       setErrorsVisible(true)
       return
     }
 
-    if (user) {
-      const formattedPassword = formatPassword(password)
-      const success = user.password === formattedPassword
+    const formattedPassword = formatPassword(password)
 
-      if (success) {
+    if (user) {
+      // Passcode re-entry for the account already loaded into the active store.
+      if (user.password === formattedPassword) {
         setIsLoggedIn(true)
         return
       }
-
       setSuccess(false)
       return
     }
 
-    dispatch(loginRequest({ name, password: formatPassword(password) }))
+    // Fresh login: try a locally registered account first (works offline), then fall back to
+    // an online login if no local account matches this name.
+    try {
+      const loggedIn = await loginToAccount(name, formattedPassword)
+      if (loggedIn) {
+        setIsLoggedIn(true)
+        return
+      }
+      dispatch(loginRequest({ name, password: formattedPassword }))
+    } catch {
+      setSuccess(false)
+    }
   }
 
   React.useEffect(() => {

--- a/app/src/screens/AuthScreen/components/LogIn.tsx
+++ b/app/src/screens/AuthScreen/components/LogIn.tsx
@@ -14,6 +14,7 @@ import { Text } from '../../../components/Text'
 import { AuthCardBody } from './AuthCardBody'
 import { loadPendingSyncData } from '../../../services/pendingSync'
 import { loginToAccount } from '../../../services/auth/accountFlows'
+import { verifyPassword } from '../../../services/auth/credentialVault'
 
 export const LogIn = () => {
   const user = useSelector(currentUserSelector)
@@ -50,8 +51,12 @@ export const LogIn = () => {
     const formattedPassword = formatPassword(password)
 
     if (user) {
-      // Passcode re-entry for the account already loaded into the active store.
-      if (user.password === formattedPassword) {
+      // Passcode re-entry for the account already loaded into the active store. Verify against
+      // the credential vault (the source of truth, kept current by offline password resets),
+      // falling back to the plaintext stored on the user for any pre-vault account.
+      const ok =
+        (await verifyPassword(user.id, formattedPassword)) || user.password === formattedPassword
+      if (ok) {
         setIsLoggedIn(true)
         return
       }

--- a/app/src/screens/AuthScreen/components/LogIn.tsx
+++ b/app/src/screens/AuthScreen/components/LogIn.tsx
@@ -8,18 +8,15 @@ import { useSelector } from '../../../redux/useSelector'
 import { currentUserSelector } from '../../../redux/selectors'
 import { useAuth } from '../../../contexts/AuthContext'
 import { formatPassword } from '../../../services/auth'
-import { useDispatch } from 'react-redux'
-import { loginRequest } from '../../../redux/actions'
 import { Text } from '../../../components/Text'
 import { AuthCardBody } from './AuthCardBody'
 import { loadPendingSyncData } from '../../../services/pendingSync'
-import { loginToAccount } from '../../../services/auth/accountFlows'
+import { loginToAccount, loginOnlineToAccount } from '../../../services/auth/accountFlows'
 import { verifyPassword } from '../../../services/auth/credentialVault'
 
 export const LogIn = () => {
   const user = useSelector(currentUserSelector)
   const [wasPreLoggedIn] = React.useState(!!user)
-  const dispatch = useDispatch()
   const { setIsLoggedIn } = useAuth()
 
   const [name, setName] = React.useState(user ? user.name : '')
@@ -31,18 +28,6 @@ export const LogIn = () => {
   const [success, setSuccess] = React.useState<boolean | null>(null)
 
   const [margin, setMargin] = React.useState(0)
-
-  // The online login path resolves in the saga (loginFailure increments this), so surface its
-  // failures here too — otherwise a wrong password / network error for a server-only account
-  // (e.g. after a reinstall) gives no feedback at all.
-  const loginFailedCount = useSelector((state) => state.auth.loginFailedCount)
-  const prevFailedCount = React.useRef(loginFailedCount)
-  React.useEffect(() => {
-    if (loginFailedCount > prevFailedCount.current) {
-      setSuccess(false)
-    }
-    prevFailedCount.current = loginFailedCount
-  }, [loginFailedCount])
 
   // Clear a stale "incorrect" message as soon as the user edits either field.
   React.useEffect(() => {
@@ -81,15 +66,19 @@ export const LogIn = () => {
       return
     }
 
-    // Fresh login: try a locally registered account first (works offline), then fall back to
-    // an online login if no local account matches this name.
+    // Fresh login: try a locally registered account first (works offline), then fall back to an
+    // online login if no local account matches this name. The online path registers the account
+    // and gives it its own store, so it joins the account switcher instead of landing in the
+    // shared anon store.
     try {
-      const loggedIn = await loginToAccount(name, formattedPassword)
+      const loggedIn =
+        (await loginToAccount(name, formattedPassword)) ||
+        (await loginOnlineToAccount(name, formattedPassword))
       if (loggedIn) {
         setIsLoggedIn(true)
         return
       }
-      dispatch(loginRequest({ name, password: formattedPassword }))
+      setSuccess(false)
     } catch {
       setSuccess(false)
     }

--- a/app/src/screens/AuthScreen/components/LogIn.tsx
+++ b/app/src/screens/AuthScreen/components/LogIn.tsx
@@ -11,7 +11,11 @@ import { formatPassword } from '../../../services/auth'
 import { Text } from '../../../components/Text'
 import { AuthCardBody } from './AuthCardBody'
 import { loadPendingSyncData } from '../../../services/pendingSync'
-import { loginToAccount, loginOnlineToAccount } from '../../../services/auth/accountFlows'
+import {
+  loginToAccount,
+  loginOnlineToAccount,
+  MAX_ACCOUNTS,
+} from '../../../services/auth/accountFlows'
 import { verifyPassword } from '../../../services/auth/credentialVault'
 
 export const LogIn = () => {
@@ -26,12 +30,16 @@ export const LogIn = () => {
   const { errors } = validateCredentials(name, password)
 
   const [success, setSuccess] = React.useState<boolean | null>(null)
+  // Which error to show when success === false. Defaults to a wrong-passcode message; the online
+  // login can instead fail because the device is full (MAX_ACCOUNTS), which is not a bad password.
+  const [errorKey, setErrorKey] = React.useState('password_incorrect')
 
   const [margin, setMargin] = React.useState(0)
 
   // Clear a stale "incorrect" message as soon as the user edits either field.
   React.useEffect(() => {
     setSuccess(null)
+    setErrorKey('password_incorrect')
   }, [name, password])
 
   // Pre-fill username from pending sync data after a forced logout
@@ -79,7 +87,10 @@ export const LogIn = () => {
         return
       }
       setSuccess(false)
-    } catch {
+    } catch (err) {
+      if (err instanceof Error && err.message === MAX_ACCOUNTS) {
+        setErrorKey('max_accounts_reached')
+      }
       setSuccess(false)
     }
   }
@@ -122,7 +133,7 @@ export const LogIn = () => {
           errorKeys={['password_too_short']}
           errorsVisible={errorsVisible}
         />
-        {success === false && <ErrorText>password_incorrect</ErrorText>}
+        {success === false && <ErrorText>{errorKey}</ErrorText>}
       </AuthCardBody>
       <Hr />
       <TouchableOpacity onPress={onConfirm} style={[styles.confirm, { marginBottom: margin }]}>

--- a/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
+++ b/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
@@ -6,6 +6,7 @@ import { formatPassword } from '../../../../services/auth'
 import { signupAccount, MAX_ACCOUNTS } from '../../../../services/auth/accountFlows'
 import { findUserByName } from '../../../../services/userMetadata/registry'
 import { useTranslate } from '../../../../hooks/useTranslate'
+import { useLoading } from '../../../../contexts/LoadingProvider'
 import { uuidv4 } from '../../../../services/uuid'
 import moment from 'moment'
 import { httpClient } from '../../../../services/HttpClient'
@@ -273,6 +274,7 @@ const SignUpContext = React.createContext<SignUpContext>(defaultValue)
 export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
   const [state, dispatch] = React.useReducer(reducer, initialState)
   const translate = useTranslate()
+  const { setLoading } = useLoading()
 
   const step = steps[state.stepIndex]
   const { isValid, errors } = validateStep(state, step)
@@ -347,7 +349,18 @@ export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
     // Create the account. signupAccount switches to its store and marks onboarding pending, which
     // routes the auth screen through avatar -> theme -> period survey. The logged-in gate is set at
     // the end of onboarding (JourneyReview.onConfirm), not here.
+    //
+    // This takes a couple of seconds on device (per-account Keychain key creation + read-back, then
+    // the per-user store build). Show the full-screen loading overlay over that gap, otherwise the
+    // sign-up card sits empty (just its "confirm" button) until the store switch remounts into
+    // onboarding. On success the store switch remounts the whole tree (overlay included), so the
+    // overlay only needs clearing on failure.
+    setLoading(true)
     signupAccount(account).catch((err) => {
+      setLoading(false)
+      // Restore the last step so a failure doesn't strand the user on the empty form shell (just
+      // its "confirm" button). They can fix input and retry.
+      dispatch({ type: 'stepIndex', value: steps.length - 1 })
       const message =
         err instanceof Error && err.message === MAX_ACCOUNTS
           ? translate('max_accounts_reached')

--- a/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
+++ b/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { User } from '../../../../types'
 import { FAST_SIGN_UP } from '../../../../config/env'
 import { Alert } from 'react-native'
-import { useAuth } from '../../../../contexts/AuthContext'
 import { formatPassword } from '../../../../services/auth'
 import { signupAccount } from '../../../../services/auth/accountFlows'
 import { findUserByName } from '../../../../services/userMetadata/registry'
@@ -276,8 +275,6 @@ export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
   const step = steps[state.stepIndex]
   const { isValid, errors } = validateStep(state, step)
 
-  const { setIsLoggedIn } = useAuth()
-
   const [debouncedName] = useDebounce(state.name, 500)
   React.useEffect(() => {
     if (!debouncedName || debouncedName.length < MINIMUM_NAME_LENGTH) {
@@ -345,11 +342,10 @@ export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
       dateSignedUp: moment.utc().toISOString(),
     }
 
-    // Set the logged-in gate before the account's store is built: AuthProvider lives above the
-    // per-user store, so this survives the store switch that signupAccount performs.
-    setIsLoggedIn(true)
+    // Create the account. signupAccount switches to its store and marks onboarding pending, which
+    // routes the auth screen through avatar -> theme -> period survey. The logged-in gate is set at
+    // the end of onboarding (JourneyReview.onConfirm), not here.
     signupAccount(account).catch((err) => {
-      setIsLoggedIn(false)
       Alert.alert('error', err instanceof Error ? err.message : 'signup_failed')
     })
   }, [step])

--- a/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
+++ b/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
@@ -5,6 +5,7 @@ import { Alert } from 'react-native'
 import { useAuth } from '../../../../contexts/AuthContext'
 import { formatPassword } from '../../../../services/auth'
 import { signupAccount } from '../../../../services/auth/accountFlows'
+import { findUserByName } from '../../../../services/userMetadata/registry'
 import { uuidv4 } from '../../../../services/uuid'
 import moment from 'moment'
 import { httpClient } from '../../../../services/HttpClient'
@@ -285,6 +286,17 @@ export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
 
     let cleanup = false
     const checkUserNameAvailability = async () => {
+      // Check the local registry first: a name already used by another offline account on this
+      // device is taken regardless of the server, and this works offline (where getUserInfo
+      // throws and would otherwise mark every name available).
+      const localMatch = await findUserByName(debouncedName)
+      if (cleanup) {
+        return
+      }
+      if (localMatch) {
+        dispatch({ type: 'nameAvailable', value: false })
+        return
+      }
       try {
         await httpClient.getUserInfo(debouncedName)
         if (cleanup) {

--- a/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
+++ b/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
@@ -3,8 +3,9 @@ import { User } from '../../../../types'
 import { FAST_SIGN_UP } from '../../../../config/env'
 import { Alert } from 'react-native'
 import { formatPassword } from '../../../../services/auth'
-import { signupAccount } from '../../../../services/auth/accountFlows'
+import { signupAccount, MAX_ACCOUNTS } from '../../../../services/auth/accountFlows'
 import { findUserByName } from '../../../../services/userMetadata/registry'
+import { useTranslate } from '../../../../hooks/useTranslate'
 import { uuidv4 } from '../../../../services/uuid'
 import moment from 'moment'
 import { httpClient } from '../../../../services/HttpClient'
@@ -271,6 +272,7 @@ const SignUpContext = React.createContext<SignUpContext>(defaultValue)
 
 export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
   const [state, dispatch] = React.useReducer(reducer, initialState)
+  const translate = useTranslate()
 
   const step = steps[state.stepIndex]
   const { isValid, errors } = validateStep(state, step)
@@ -346,7 +348,11 @@ export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
     // routes the auth screen through avatar -> theme -> period survey. The logged-in gate is set at
     // the end of onboarding (JourneyReview.onConfirm), not here.
     signupAccount(account).catch((err) => {
-      Alert.alert('error', err instanceof Error ? err.message : 'signup_failed')
+      const message =
+        err instanceof Error && err.message === MAX_ACCOUNTS
+          ? translate('max_accounts_reached')
+          : translate('something_went_wrong')
+      Alert.alert(translate('error'), message)
     })
   }, [step])
 

--- a/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
+++ b/app/src/screens/AuthScreen/components/SignUp/SignUpContext.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { User } from '../../../../types'
 import { FAST_SIGN_UP } from '../../../../config/env'
-import { useAuthMode } from '../../AuthModeContext'
-import { useDispatch } from 'react-redux'
-import { createAccountRequest } from '../../../../redux/actions'
+import { Alert } from 'react-native'
+import { useAuth } from '../../../../contexts/AuthContext'
 import { formatPassword } from '../../../../services/auth'
+import { signupAccount } from '../../../../services/auth/accountFlows'
 import { uuidv4 } from '../../../../services/uuid'
 import moment from 'moment'
 import { httpClient } from '../../../../services/HttpClient'
@@ -275,9 +275,7 @@ export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
   const step = steps[state.stepIndex]
   const { isValid, errors } = validateStep(state, step)
 
-  const { setAuthMode } = useAuthMode()
-
-  const reduxDispatch = useDispatch()
+  const { setIsLoggedIn } = useAuth()
 
   const [debouncedName] = useDebounce(state.name, 500)
   React.useEffect(() => {
@@ -320,7 +318,7 @@ export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
       return
     }
 
-    const user = {
+    const account = {
       id: uuidv4(),
       name: state.name,
       password: formatPassword(state.password),
@@ -333,12 +331,15 @@ export const SignUpProvider = ({ children }: React.PropsWithChildren) => {
       dateOfBirth: state.dateOfBirth,
       metadata: state.metadata,
       dateSignedUp: moment.utc().toISOString(),
-      isGuest: false,
     }
 
-    reduxDispatch(createAccountRequest(user))
-    // TODO: wait for success
-    setAuthMode('avatar_selection')
+    // Set the logged-in gate before the account's store is built: AuthProvider lives above the
+    // per-user store, so this survives the store switch that signupAccount performs.
+    setIsLoggedIn(true)
+    signupAccount(account).catch((err) => {
+      setIsLoggedIn(false)
+      Alert.alert('error', err instanceof Error ? err.message : 'signup_failed')
+    })
   }, [step])
 
   return (

--- a/app/src/screens/AuthScreen/index.tsx
+++ b/app/src/screens/AuthScreen/index.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../components/Button'
 import AnimatedContainer from '../../components/AnimatedContainer'
 import { SignUp } from './components/SignUp'
 import { AuthToggle } from './components/AuthToggle'
+import { AccountSwitcher } from './components/AccountSwitcher'
 import { AuthModeProvider, useAuthMode } from './AuthModeContext'
 import { ScreenProps } from '../../navigation/RootNavigator'
 import { AvatarSelect } from '../AvatarScreen'
@@ -67,6 +68,7 @@ const AuthScreenInner = ({ navigation }: ScreenProps<'Auth'>) => {
 
       <View style={[styles.wrapper, globalStyles.shadow]}>
         <AnimatedContainer style={[styles.container, { backgroundColor }, globalStyles.elevation]}>
+          {authMode === 'start' && <AccountSwitcher />}
           {authMode === 'start' && <AuthToggle />}
           {authMode === 'log_in' && <LogIn />}
           {authMode === 'sign_up' && <SignUp />}

--- a/app/src/screens/SettingsScreen/index.tsx
+++ b/app/src/screens/SettingsScreen/index.tsx
@@ -6,9 +6,7 @@ import { ScreenComponent } from '../../navigation/RootNavigator'
 import { TouchableRow, TouchableRowProps } from '../../components/TouchableRow'
 import FontAwesome from '@expo/vector-icons/FontAwesome'
 import { Switch } from '../../components/Switch'
-import { useDispatch } from 'react-redux'
-import { deleteAccountRequest } from '../../redux/actions'
-import { logoutToAnon } from '../../services/auth/accountFlows'
+import { logoutToAnon, deleteActiveAccount } from '../../services/auth/accountFlows'
 import { useAuth } from '../../contexts/AuthContext'
 import { useSelector } from '../../redux/useSelector'
 import { appTokenSelector, currentUserSelector } from '../../redux/selectors'
@@ -19,7 +17,6 @@ import { useColor } from '../../hooks/useColor'
 const SettingsScreen: ScreenComponent<'Settings'> = ({ navigation }) => {
   const currentUser = useSelector(currentUserSelector)
   const appToken = useSelector(appTokenSelector)
-  const dispatch = useDispatch()
   const { setIsLoggedIn } = useAuth()
   const translate = useTranslate()
   const { palette, backgroundColor } = useColor()
@@ -34,13 +31,14 @@ const SettingsScreen: ScreenComponent<'Settings'> = ({ navigation }) => {
     if (!currentUser) {
       return
     }
-    dispatch(
-      deleteAccountRequest({
-        name: currentUser.name,
-        password: currentUser.password,
-        // setLoading, TODO: ?
-      }),
-    )
+    // Leave the logged-in gate first (AuthProvider lives above the per-user store), then tear the
+    // account down (server delete + registry entry + encryption key + credential vault + store
+    // blob) outside the saga, mirroring the AuthScreen delete flow.
+    setIsLoggedIn(false)
+    void deleteActiveAccount({
+      name: currentUser.name,
+      password: currentUser.password,
+    })
   }
 
   const logOutAlert = () => {

--- a/app/src/screens/SettingsScreen/index.tsx
+++ b/app/src/screens/SettingsScreen/index.tsx
@@ -7,7 +7,8 @@ import { TouchableRow, TouchableRowProps } from '../../components/TouchableRow'
 import FontAwesome from '@expo/vector-icons/FontAwesome'
 import { Switch } from '../../components/Switch'
 import { useDispatch } from 'react-redux'
-import { deleteAccountRequest, logoutRequest } from '../../redux/actions'
+import { deleteAccountRequest } from '../../redux/actions'
+import { logoutToAnon } from '../../services/auth/accountFlows'
 import { useAuth } from '../../contexts/AuthContext'
 import { useSelector } from '../../redux/useSelector'
 import { appTokenSelector, currentUserSelector } from '../../redux/selectors'
@@ -24,7 +25,8 @@ const SettingsScreen: ScreenComponent<'Settings'> = ({ navigation }) => {
   const { palette, backgroundColor } = useColor()
 
   const logOut = () => {
-    dispatch(logoutRequest())
+    // Leave the active account for the logged-out (anon) context, keeping its data saved.
+    void logoutToAnon()
     setIsLoggedIn(false)
   }
 

--- a/app/src/services/HttpClient.ts
+++ b/app/src/services/HttpClient.ts
@@ -124,6 +124,7 @@ export function createHttpClient(
       dateSignedUp,
       metadata,
       preferredId = null,
+      deviceId,
     }: // TODO:
     // eslint-disable-next-line
     any) => {
@@ -142,6 +143,7 @@ export function createHttpClient(
           dateSignedUp,
           metadata,
           preferredId,
+          deviceId,
           dateAccountSaved: new Date().toISOString(),
         },
       )

--- a/app/src/services/auth/accountFlows.ts
+++ b/app/src/services/auth/accountFlows.ts
@@ -1,0 +1,132 @@
+// Orchestrates every change to the ACTIVE account: signup, login, switch, delete.
+// These must live outside the per-user redux saga, because storeManager.switchToUser tears
+// down and rebuilds the active store (cancelling the saga that called it). The UI calls these
+// directly. Each updates the registry and credential vault, switches the per-user store, and
+// dispatches the resulting user into the freshly built store.
+import { getActiveBundle, switchToUser } from '../../redux/storeManager'
+import { ANON_USER_ID } from '../storage/storageKeys'
+import { loginSuccess } from '../../redux/actions'
+import * as registry from '../userMetadata/registry'
+import { saveCredential, verifyPassword, setNewPassword, verifySecretAnswer } from './credentialVault'
+import { getDeviceId } from '../deviceId'
+import { uuidv4 } from '../uuid'
+
+export const MAX_ACCOUNTS = registry.MAX_ACCOUNTS_ERROR
+
+export interface NewAccount {
+  id?: string
+  name: string
+  password: string
+  secretQuestion?: string
+  secretAnswer?: string
+  gender?: string
+  location?: string
+  country?: string
+  province?: string
+  dateOfBirth?: string
+  dateSignedUp: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  metadata?: any
+}
+
+function toUser(id: string, a: NewAccount) {
+  return {
+    id,
+    name: a.name,
+    password: a.password,
+    secretQuestion: a.secretQuestion ?? '',
+    secretAnswer: a.secretAnswer ?? '',
+    gender: a.gender ?? '',
+    location: a.location ?? '',
+    country: a.country ?? '',
+    province: a.province ?? '',
+    dateOfBirth: a.dateOfBirth ?? '',
+    dateSignedUp: a.dateSignedUp,
+    isGuest: false as const,
+    metadata: a.metadata ?? {},
+  }
+}
+
+function dispatchUser(user: ReturnType<typeof toUser>): void {
+  const bundle = getActiveBundle()
+  // appToken is undefined until the account syncs to the server.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bundle?.store.dispatch(loginSuccess({ appToken: undefined as any, user: user as any }))
+}
+
+// Create a new account: register it, store its credentials, give it its own store, and make
+// it active and logged in. Marked pending-sync so the server registration can happen later.
+export async function signupAccount(a: NewAccount): Promise<{ userId: string }> {
+  const existing = await registry.findUserByName(a.name)
+  if (existing) {
+    throw new Error('name_taken')
+  }
+  const deviceId = await getDeviceId()
+  const userId = a.id || uuidv4()
+  // Throws MAX_ACCOUNTS_ERROR if the device already has the maximum number of accounts.
+  await registry.addUser({ id: userId, name: a.name, deviceId, isPendingSync: true, appToken: null })
+  await saveCredential({
+    userId,
+    password: a.password,
+    secretAnswer: a.secretAnswer ?? null,
+    keepPlainForSync: true,
+  })
+  await switchToUser(userId)
+  dispatchUser(toUser(userId, a))
+  return { userId }
+}
+
+// Attempt an offline login against a locally registered account. Returns false if no local
+// account exists for that name (caller may then fall back to an online login). Throws
+// 'login_failed' if the account exists but the password is wrong.
+export async function loginToAccount(name: string, password: string): Promise<boolean> {
+  const account = await registry.findUserByName(name)
+  if (!account) {
+    return false
+  }
+  const ok = await verifyPassword(account.id, password)
+  if (!ok) {
+    throw new Error('login_failed')
+  }
+  await switchToUser(account.id)
+  return true
+}
+
+// Reset an account's password offline by verifying its secret answer.
+export async function resetPasswordOffline(
+  name: string,
+  secretAnswer: string,
+  newPassword: string,
+): Promise<boolean> {
+  const account = await registry.findUserByName(name)
+  if (!account) {
+    return false
+  }
+  const ok = await verifySecretAnswer(account.id, secretAnswer)
+  if (!ok) {
+    throw new Error('wrong_secret_answer')
+  }
+  await setNewPassword(account.id, newPassword)
+  return true
+}
+
+export async function switchToAccount(userId: string): Promise<void> {
+  await switchToUser(userId)
+}
+
+// Leave the active account and return to the logged-out (anon) context.
+export async function logoutToAnon(): Promise<void> {
+  await switchToUser(ANON_USER_ID)
+}
+
+// Remove an account entirely (registry entry, per-user store, credentials) and switch away
+// from it if it was active.
+export async function deleteAccount(userId: string): Promise<void> {
+  await registry.removeUser(userId)
+  const remaining = await registry.listUsers()
+  await switchToUser(remaining.length > 0 ? remaining[0].id : ANON_USER_ID)
+}
+
+export async function listAccounts() {
+  return registry.listUsers()
+}

--- a/app/src/services/auth/accountFlows.ts
+++ b/app/src/services/auth/accountFlows.ts
@@ -5,7 +5,13 @@
 // dispatches the resulting user into the freshly built store.
 import { getActiveBundle, switchToUser } from '../../redux/storeManager'
 import { ANON_USER_ID } from '../storage/storageKeys'
-import { loginSuccess, setLocale, setTheme, setAvatar } from '../../redux/actions'
+import {
+  loginSuccess,
+  setLocale,
+  setTheme,
+  setAvatar,
+  setOnboardingPending,
+} from '../../redux/actions'
 import * as registry from '../userMetadata/registry'
 import {
   saveCredential,
@@ -15,6 +21,7 @@ import {
   deleteCredential,
 } from './credentialVault'
 import { createEncryptionKey, deleteEncryptionKey } from './encryptionKeys'
+import { consumePendingLocale } from './pendingLocale'
 import { getDeviceId } from '../deviceId'
 import { httpClient } from '../HttpClient'
 import { uuidv4 } from '../uuid'
@@ -69,6 +76,9 @@ export async function signupAccount(a: NewAccount): Promise<{ userId: string }> 
   const prevApp = (getActiveBundle()?.store.getState() as any)?.app as
     | { locale?: string; theme?: string; avatar?: string }
     | undefined
+  // The locale is carried via prevApp below; clear any pending auth-screen pick so it is not also
+  // applied to a later login.
+  consumePendingLocale()
   const deviceId = await getDeviceId()
   const userId = a.id || uuidv4()
   // Create this account's own Keychain key first. If the Keychain is present but the key did not
@@ -116,6 +126,10 @@ export async function signupAccount(a: NewAccount): Promise<{ userId: string }> 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     bundle.store.dispatch(setAvatar(prevApp.avatar as any))
   }
+  // Mark onboarding as pending so the auth screen routes the new account through avatar -> theme ->
+  // period survey before reaching home. The flag lives in the new account's store, so it survives
+  // the store-switch remount and is cleared when the survey is confirmed.
+  bundle.store.dispatch(setOnboardingPending(true))
   bundle.store.dispatch(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     loginSuccess({ appToken: undefined as any, user: toUser(userId, a) as any }),
@@ -135,7 +149,12 @@ export async function loginToAccount(name: string, password: string): Promise<bo
   if (!ok) {
     throw new Error('login_failed')
   }
-  await switchToUser(account.id)
+  const bundle = await switchToUser(account.id)
+  // If the user picked a language on the auth screen, carry it into this account's store.
+  const carriedLocale = consumePendingLocale()
+  if (carriedLocale) {
+    bundle.store.dispatch(setLocale(carriedLocale))
+  }
   return true
 }
 
@@ -158,7 +177,12 @@ export async function resetPasswordOffline(
 }
 
 export async function switchToAccount(userId: string): Promise<void> {
-  await switchToUser(userId)
+  const bundle = await switchToUser(userId)
+  // Carry a language picked on the auth screen into the account being switched to.
+  const carriedLocale = consumePendingLocale()
+  if (carriedLocale) {
+    bundle.store.dispatch(setLocale(carriedLocale))
+  }
 }
 
 // Leave the active account and return to the logged-out (anon) context.

--- a/app/src/services/auth/accountFlows.ts
+++ b/app/src/services/auth/accountFlows.ts
@@ -8,6 +8,7 @@ import { ANON_USER_ID } from '../storage/storageKeys'
 import { loginSuccess } from '../../redux/actions'
 import * as registry from '../userMetadata/registry'
 import { saveCredential, verifyPassword, setNewPassword, verifySecretAnswer } from './credentialVault'
+import { createEncryptionKey, deleteEncryptionKey } from './encryptionKeys'
 import { getDeviceId } from '../deviceId'
 import { uuidv4 } from '../uuid'
 
@@ -63,6 +64,8 @@ export async function signupAccount(a: NewAccount): Promise<{ userId: string }> 
   }
   const deviceId = await getDeviceId()
   const userId = a.id || uuidv4()
+  // Create this account's own encryption key (Keychain) before its store and vault are written.
+  await createEncryptionKey(userId)
   // Throws MAX_ACCOUNTS_ERROR if the device already has the maximum number of accounts.
   await registry.addUser({ id: userId, name: a.name, deviceId, isPendingSync: true, appToken: null })
   await saveCredential({
@@ -123,6 +126,7 @@ export async function logoutToAnon(): Promise<void> {
 // logged-out (anon) context.
 export async function deleteAccount(userId: string): Promise<void> {
   await registry.removeUser(userId)
+  await deleteEncryptionKey(userId)
   await switchToUser(ANON_USER_ID)
 }
 

--- a/app/src/services/auth/accountFlows.ts
+++ b/app/src/services/auth/accountFlows.ts
@@ -11,7 +11,9 @@ import {
   setTheme,
   setAvatar,
   setOnboardingPending,
+  refreshStore,
 } from '../../redux/actions'
+import { loadPendingSyncData, clearPendingSyncData, PendingSyncData } from '../pendingSync'
 import * as registry from '../userMetadata/registry'
 import {
   saveCredential,
@@ -152,6 +154,112 @@ export async function loginToAccount(name: string, password: string): Promise<bo
   const bundle = await switchToUser(account.id)
   // If the user picked a language on the auth screen, carry it into this account's store.
   const carriedLocale = consumePendingLocale()
+  if (carriedLocale) {
+    bundle.store.dispatch(setLocale(carriedLocale))
+  }
+  return true
+}
+
+// Re-upload data that was queued before a 431-forced logout. Best-effort: a failure here must
+// never block the login. Mirrors the saga's resendPendingSyncDataToServer.
+async function resendPendingSyncData(appToken: string, pending: PendingSyncData): Promise<void> {
+  try {
+    await httpClient.replaceStore({
+      storeVersion: pending.replaceStore.storeVersion,
+      appState: pending.replaceStore.appState,
+      appToken,
+    })
+    await httpClient.editUserInfo({ appToken, ...pending.editInfo })
+    await clearPendingSyncData()
+  } catch {
+    // Best-effort: keep the pending data for the next attempt.
+  }
+}
+
+// Online login for an account that is NOT yet registered on this device. Authenticates against the
+// server, then creates a proper local account (registry entry, credential vault, per-account
+// encryption key) and switches to its OWN store — mirroring loginToAccount/signupAccount. This is
+// what makes a server account appear in the account switcher and keeps its data out of the shared
+// anon store. Returns false if the server returns no usable user; throws on auth/network failure so
+// the caller can surface it. Runs outside the saga because switchToUser tears the saga down.
+export async function loginOnlineToAccount(name: string, password: string): Promise<boolean> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { appToken, user, store }: any = await httpClient.login({ name, password })
+  if (!user?.id) {
+    return false
+  }
+  const userId: string = user.id
+
+  // A language picked on the auth screen, to carry into the new account's store.
+  const carriedLocale = consumePendingLocale()
+
+  // Data saved before a 431-forced logout for THIS user takes precedence over the server snapshot.
+  const pendingData = await loadPendingSyncData()
+  const hasPendingData = !!pendingData && pendingData.userId === userId
+
+  const deviceId = await getDeviceId()
+  // Per-account Keychain key, with the same durability guard as signup: never encrypt the account's
+  // data under a key that did not persist (it would be unrecoverable on restart).
+  const keyResult = await createEncryptionKey(userId)
+  if (keyResult.secureStoreAvailable && !keyResult.persisted) {
+    await deleteEncryptionKey(userId)
+    throw new Error('keystore_unavailable')
+  }
+  try {
+    await saveCredential({ userId, password, secretAnswer: null, keepPlainForSync: true })
+    // Already on the server, so not pending-sync; record the server id and token.
+    await registry.addUser({
+      id: userId,
+      name,
+      deviceId,
+      isPendingSync: false,
+      serverId: user.id,
+      appToken: appToken ?? null,
+      hasEncryptionKey: keyResult.persisted,
+    })
+  } catch (err) {
+    await deleteCredential(userId).catch(() => undefined)
+    await deleteEncryptionKey(userId).catch(() => undefined)
+    throw err
+  }
+
+  // Build (and switch to) this account's own store, then populate it. Dispatch into the returned
+  // bundle, never getActiveBundle(), which a concurrent switch could have replaced.
+  const bundle = await switchToUser(userId)
+  const userForState = hasPendingData
+    ? { ...user, ...pendingData!.editInfo, name, password, isGuest: false as const }
+    : { ...user, name, password, isGuest: false as const }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  bundle.store.dispatch(loginSuccess({ appToken, user: userForState as any }))
+
+  if (hasPendingData) {
+    const pendingAppState = pendingData!.replaceStore.appState
+    bundle.store.dispatch(
+      refreshStore({
+        userID: userId,
+        ...pendingAppState,
+        ...(pendingAppState.app
+          ? { app: { ...pendingAppState.app, ...(carriedLocale ? { locale: carriedLocale } : {}) } }
+          : {}),
+      }),
+    )
+    void resendPendingSyncData(appToken, pendingData!)
+  } else {
+    if (pendingData) {
+      // Pending data belongs to a different user: discard it.
+      await clearPendingSyncData()
+    }
+    if (store && store.storeVersion >= 0 && store.appState) {
+      bundle.store.dispatch(
+        refreshStore({
+          userID: userId,
+          ...store.appState,
+          app: { ...store.appState.app, ...(carriedLocale ? { locale: carriedLocale } : {}) },
+        }),
+      )
+    }
+  }
+
   if (carriedLocale) {
     bundle.store.dispatch(setLocale(carriedLocale))
   }

--- a/app/src/services/auth/accountFlows.ts
+++ b/app/src/services/auth/accountFlows.ts
@@ -7,9 +7,16 @@ import { getActiveBundle, switchToUser } from '../../redux/storeManager'
 import { ANON_USER_ID } from '../storage/storageKeys'
 import { loginSuccess } from '../../redux/actions'
 import * as registry from '../userMetadata/registry'
-import { saveCredential, verifyPassword, setNewPassword, verifySecretAnswer } from './credentialVault'
+import {
+  saveCredential,
+  verifyPassword,
+  setNewPassword,
+  verifySecretAnswer,
+  deleteCredential,
+} from './credentialVault'
 import { createEncryptionKey, deleteEncryptionKey } from './encryptionKeys'
 import { getDeviceId } from '../deviceId'
+import { httpClient } from '../HttpClient'
 import { uuidv4 } from '../uuid'
 
 export const MAX_ACCOUNTS = registry.MAX_ACCOUNTS_ERROR
@@ -48,13 +55,6 @@ function toUser(id: string, a: NewAccount) {
   }
 }
 
-function dispatchUser(user: ReturnType<typeof toUser>): void {
-  const bundle = getActiveBundle()
-  // appToken is undefined until the account syncs to the server.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  bundle?.store.dispatch(loginSuccess({ appToken: undefined as any, user: user as any }))
-}
-
 // Create a new account: register it, store its credentials, give it its own store, and make
 // it active and logged in. Marked pending-sync so the server registration can happen later.
 export async function signupAccount(a: NewAccount): Promise<{ userId: string }> {
@@ -64,18 +64,43 @@ export async function signupAccount(a: NewAccount): Promise<{ userId: string }> 
   }
   const deviceId = await getDeviceId()
   const userId = a.id || uuidv4()
-  // Create this account's own encryption key (Keychain) before its store and vault are written.
-  await createEncryptionKey(userId)
-  // Throws MAX_ACCOUNTS_ERROR if the device already has the maximum number of accounts.
-  await registry.addUser({ id: userId, name: a.name, deviceId, isPendingSync: true, appToken: null })
-  await saveCredential({
-    userId,
-    password: a.password,
-    secretAnswer: a.secretAnswer ?? null,
-    keepPlainForSync: true,
-  })
-  await switchToUser(userId)
-  dispatchUser(toUser(userId, a))
+  // Create this account's own Keychain key first. If the Keychain is present but the key did not
+  // durably persist, abort rather than encrypt the account's data under a key lost on restart.
+  const keyResult = await createEncryptionKey(userId)
+  if (keyResult.secureStoreAvailable && !keyResult.persisted) {
+    await deleteEncryptionKey(userId)
+    throw new Error('keystore_unavailable')
+  }
+  try {
+    await saveCredential({
+      userId,
+      password: a.password,
+      secretAnswer: a.secretAnswer ?? null,
+      keepPlainForSync: true,
+    })
+    // The registry entry is written LAST and throws MAX_ACCOUNTS_ERROR if the device is full, so a
+    // registered account always implies a usable credential record and encryption key.
+    await registry.addUser({
+      id: userId,
+      name: a.name,
+      deviceId,
+      isPendingSync: true,
+      appToken: null,
+      hasEncryptionKey: keyResult.persisted,
+    })
+  } catch (err) {
+    // Roll back the partial writes so a failed signup never leaves an orphaned half-created account.
+    await deleteCredential(userId).catch(() => undefined)
+    await deleteEncryptionKey(userId).catch(() => undefined)
+    throw err
+  }
+  // Dispatch into the bundle we just built (never getActiveBundle(), which a concurrent switch
+  // could have replaced). appToken is undefined until the account syncs to the server.
+  const bundle = await switchToUser(userId)
+  bundle.store.dispatch(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    loginSuccess({ appToken: undefined as any, user: toUser(userId, a) as any }),
+  )
   return { userId }
 }
 
@@ -128,6 +153,29 @@ export async function deleteAccount(userId: string): Promise<void> {
   await registry.removeUser(userId)
   await deleteEncryptionKey(userId)
   await switchToUser(ANON_USER_ID)
+}
+
+// Delete the currently active (logged-in) account. Best-effort server delete, then full local
+// teardown (registry entry, encryption key, credential vault, store blob) and return to anon.
+// Lives here, outside the per-user saga, because the store teardown cancels that saga; the in-app
+// Settings delete must call this directly rather than dispatching into the saga.
+export async function deleteActiveAccount(credentials?: {
+  name: string
+  password: string
+}): Promise<void> {
+  const userId = getActiveBundle()?.userId
+  if (credentials) {
+    try {
+      await httpClient.deleteUserFromPassword(credentials)
+    } catch {
+      // Offline, or the account was never registered on the server: the local teardown still runs.
+    }
+  }
+  if (userId && userId !== ANON_USER_ID) {
+    await deleteAccount(userId)
+  } else {
+    await switchToUser(ANON_USER_ID)
+  }
 }
 
 // Delete a locally registered account after verifying its password. Returns false if no local

--- a/app/src/services/auth/accountFlows.ts
+++ b/app/src/services/auth/accountFlows.ts
@@ -119,12 +119,27 @@ export async function logoutToAnon(): Promise<void> {
   await switchToUser(ANON_USER_ID)
 }
 
-// Remove an account entirely (registry entry, per-user store, credentials) and switch away
-// from it if it was active.
+// Remove an account entirely (registry entry, per-user store, credentials) and return to the
+// logged-out (anon) context.
 export async function deleteAccount(userId: string): Promise<void> {
   await registry.removeUser(userId)
-  const remaining = await registry.listUsers()
-  await switchToUser(remaining.length > 0 ? remaining[0].id : ANON_USER_ID)
+  await switchToUser(ANON_USER_ID)
+}
+
+// Delete a locally registered account after verifying its password. Returns false if no local
+// account matches the name (caller may fall back to an online delete). Throws 'login_failed'
+// if the password is wrong.
+export async function deleteAccountByPassword(name: string, password: string): Promise<boolean> {
+  const account = await registry.findUserByName(name)
+  if (!account) {
+    return false
+  }
+  const ok = await verifyPassword(account.id, password)
+  if (!ok) {
+    throw new Error('login_failed')
+  }
+  await deleteAccount(account.id)
+  return true
 }
 
 export async function listAccounts() {

--- a/app/src/services/auth/accountFlows.ts
+++ b/app/src/services/auth/accountFlows.ts
@@ -5,7 +5,7 @@
 // dispatches the resulting user into the freshly built store.
 import { getActiveBundle, switchToUser } from '../../redux/storeManager'
 import { ANON_USER_ID } from '../storage/storageKeys'
-import { loginSuccess } from '../../redux/actions'
+import { loginSuccess, setLocale, setTheme, setAvatar } from '../../redux/actions'
 import * as registry from '../userMetadata/registry'
 import {
   saveCredential,
@@ -62,6 +62,13 @@ export async function signupAccount(a: NewAccount): Promise<{ userId: string }> 
   if (existing) {
     throw new Error('name_taken')
   }
+  // Capture the language/theme/avatar the user picked on the auth screen. These live in the
+  // active (anon) store's app slice and would otherwise be lost when we switch to the new
+  // account's fresh store, which resets them to the device/app defaults.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prevApp = (getActiveBundle()?.store.getState() as any)?.app as
+    | { locale?: string; theme?: string; avatar?: string }
+    | undefined
   const deviceId = await getDeviceId()
   const userId = a.id || uuidv4()
   // Create this account's own Keychain key first. If the Keychain is present but the key did not
@@ -97,6 +104,18 @@ export async function signupAccount(a: NewAccount): Promise<{ userId: string }> 
   // Dispatch into the bundle we just built (never getActiveBundle(), which a concurrent switch
   // could have replaced). appToken is undefined until the account syncs to the server.
   const bundle = await switchToUser(userId)
+  // Carry the onboarding selections into the new account's store before it renders.
+  if (prevApp?.locale) {
+    bundle.store.dispatch(setLocale(prevApp.locale))
+  }
+  if (prevApp?.theme) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    bundle.store.dispatch(setTheme(prevApp.theme as any))
+  }
+  if (prevApp?.avatar) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    bundle.store.dispatch(setAvatar(prevApp.avatar as any))
+  }
   bundle.store.dispatch(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     loginSuccess({ appToken: undefined as any, user: toUser(userId, a) as any }),

--- a/app/src/services/auth/credentialVault.ts
+++ b/app/src/services/auth/credentialVault.ts
@@ -1,13 +1,12 @@
 // Per-user credential record. Stores the password / secret-answer hashes for offline
-// verification, and (until the account syncs to the server) the AES-encrypted plaintext
-// needed to register the account online later. Everything is AsyncStorage plus pure-JS
-// crypto, so no native rebuild is needed. Keychain (expo-secure-store) is a future
-// hardening step that would require a native build.
+// verification, and (until the account syncs to the server) the plaintext needed to register the
+// account online later, AES-encrypted with that account's per-user key from the Keychain (see
+// encryptionKeys). Stored in AsyncStorage; the protection is the Keychain-held key.
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import CryptoJS from 'crypto-js'
-import { config } from '../../resources/redux'
 import { credentialKey } from '../storage/storageKeys'
 import { hashSecret, verifySecret } from './hashUtils'
+import { getEncryptionKey } from './encryptionKeys'
 
 interface StoredCredential {
   passwordHash: string
@@ -19,18 +18,16 @@ interface StoredCredential {
   encSecretAnswer?: string
 }
 
-const KEY: string = config.REDUX_ENCRYPT_KEY
-
-function encrypt(plain: string): string {
-  return CryptoJS.AES.encrypt(plain, KEY).toString()
+function encrypt(plain: string, key: string): string {
+  return CryptoJS.AES.encrypt(plain, key).toString()
 }
 
-function decrypt(cipher: string | undefined): string | null {
+function decrypt(cipher: string | undefined, key: string): string | null {
   if (!cipher) {
     return null
   }
   try {
-    const text = CryptoJS.AES.decrypt(cipher, KEY).toString(CryptoJS.enc.Utf8)
+    const text = CryptoJS.AES.decrypt(cipher, key).toString(CryptoJS.enc.Utf8)
     return text || null
   } catch {
     return null
@@ -66,9 +63,10 @@ export async function saveCredential(params: {
     secretAnswerSalt: sa ? sa.salt : null,
   }
   if (keepPlainForSync) {
-    record.encPassword = encrypt(password)
+    const key = await getEncryptionKey(userId)
+    record.encPassword = encrypt(password, key)
     if (secretAnswer) {
-      record.encSecretAnswer = encrypt(secretAnswer)
+      record.encSecretAnswer = encrypt(secretAnswer, key)
     }
   }
   await write(userId, record)
@@ -93,12 +91,13 @@ export async function verifySecretAnswer(userId: string, answer: string): Promis
 export async function setNewPassword(userId: string, password: string): Promise<void> {
   const rec = await read(userId)
   const pw = hashSecret(password)
+  const key = await getEncryptionKey(userId)
   await write(userId, {
     passwordHash: pw.hash,
     passwordSalt: pw.salt,
     secretAnswerHash: rec ? rec.secretAnswerHash : null,
     secretAnswerSalt: rec ? rec.secretAnswerSalt : null,
-    encPassword: encrypt(password),
+    encPassword: encrypt(password, key),
     encSecretAnswer: rec ? rec.encSecretAnswer : undefined,
   })
 }
@@ -110,7 +109,11 @@ export async function getSyncSecrets(
   if (!rec) {
     return { password: null, secretAnswer: null }
   }
-  return { password: decrypt(rec.encPassword), secretAnswer: decrypt(rec.encSecretAnswer) }
+  const key = await getEncryptionKey(userId)
+  return {
+    password: decrypt(rec.encPassword, key),
+    secretAnswer: decrypt(rec.encSecretAnswer, key),
+  }
 }
 
 export async function clearSyncSecrets(userId: string): Promise<void> {

--- a/app/src/services/auth/credentialVault.ts
+++ b/app/src/services/auth/credentialVault.ts
@@ -1,0 +1,132 @@
+// Per-user credential record. Stores the password / secret-answer hashes for offline
+// verification, and (until the account syncs to the server) the AES-encrypted plaintext
+// needed to register the account online later. Everything is AsyncStorage plus pure-JS
+// crypto, so no native rebuild is needed. Keychain (expo-secure-store) is a future
+// hardening step that would require a native build.
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import CryptoJS from 'crypto-js'
+import { config } from '../../resources/redux'
+import { credentialKey } from '../storage/storageKeys'
+import { hashSecret, verifySecret } from './hashUtils'
+
+interface StoredCredential {
+  passwordHash: string
+  passwordSalt: string
+  secretAnswerHash: string | null
+  secretAnswerSalt: string | null
+  // AES-encrypted plaintext, present only until the account is synced to the server.
+  encPassword?: string
+  encSecretAnswer?: string
+}
+
+const KEY: string = config.REDUX_ENCRYPT_KEY
+
+function encrypt(plain: string): string {
+  return CryptoJS.AES.encrypt(plain, KEY).toString()
+}
+
+function decrypt(cipher: string | undefined): string | null {
+  if (!cipher) {
+    return null
+  }
+  try {
+    const text = CryptoJS.AES.decrypt(cipher, KEY).toString(CryptoJS.enc.Utf8)
+    return text || null
+  } catch {
+    return null
+  }
+}
+
+async function read(userId: string): Promise<StoredCredential | null> {
+  try {
+    const raw = await AsyncStorage.getItem(credentialKey(userId))
+    return raw ? (JSON.parse(raw) as StoredCredential) : null
+  } catch {
+    return null
+  }
+}
+
+async function write(userId: string, record: StoredCredential): Promise<void> {
+  await AsyncStorage.setItem(credentialKey(userId), JSON.stringify(record))
+}
+
+export async function saveCredential(params: {
+  userId: string
+  password: string
+  secretAnswer?: string | null
+  keepPlainForSync?: boolean
+}): Promise<void> {
+  const { userId, password, secretAnswer, keepPlainForSync = true } = params
+  const pw = hashSecret(password)
+  const sa = secretAnswer ? hashSecret(secretAnswer) : null
+  const record: StoredCredential = {
+    passwordHash: pw.hash,
+    passwordSalt: pw.salt,
+    secretAnswerHash: sa ? sa.hash : null,
+    secretAnswerSalt: sa ? sa.salt : null,
+  }
+  if (keepPlainForSync) {
+    record.encPassword = encrypt(password)
+    if (secretAnswer) {
+      record.encSecretAnswer = encrypt(secretAnswer)
+    }
+  }
+  await write(userId, record)
+}
+
+export async function verifyPassword(userId: string, password: string): Promise<boolean> {
+  const rec = await read(userId)
+  if (!rec) {
+    return false
+  }
+  return verifySecret(password, rec.passwordHash, rec.passwordSalt)
+}
+
+export async function verifySecretAnswer(userId: string, answer: string): Promise<boolean> {
+  const rec = await read(userId)
+  if (!rec || !rec.secretAnswerHash || !rec.secretAnswerSalt) {
+    return false
+  }
+  return verifySecret(answer, rec.secretAnswerHash, rec.secretAnswerSalt)
+}
+
+export async function setNewPassword(userId: string, password: string): Promise<void> {
+  const rec = await read(userId)
+  const pw = hashSecret(password)
+  await write(userId, {
+    passwordHash: pw.hash,
+    passwordSalt: pw.salt,
+    secretAnswerHash: rec ? rec.secretAnswerHash : null,
+    secretAnswerSalt: rec ? rec.secretAnswerSalt : null,
+    encPassword: encrypt(password),
+    encSecretAnswer: rec ? rec.encSecretAnswer : undefined,
+  })
+}
+
+export async function getSyncSecrets(
+  userId: string,
+): Promise<{ password: string | null; secretAnswer: string | null }> {
+  const rec = await read(userId)
+  if (!rec) {
+    return { password: null, secretAnswer: null }
+  }
+  return { password: decrypt(rec.encPassword), secretAnswer: decrypt(rec.encSecretAnswer) }
+}
+
+export async function clearSyncSecrets(userId: string): Promise<void> {
+  const rec = await read(userId)
+  if (!rec) {
+    return
+  }
+  delete rec.encPassword
+  delete rec.encSecretAnswer
+  await write(userId, rec)
+}
+
+export async function deleteCredential(userId: string): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(credentialKey(userId))
+  } catch {
+    // already gone
+  }
+}

--- a/app/src/services/auth/encryptionKeys.ts
+++ b/app/src/services/auth/encryptionKeys.ts
@@ -1,0 +1,70 @@
+// Per-account encryption key, stored in the OS Keychain/Keystore via expo-secure-store. Used to
+// encrypt that account's redux store and credential vault, so a leak of one account's key (or the
+// on-disk blobs) does not expose the others. Accounts created before this existed have no stored
+// key and fall back to the app's global key, so their already-encrypted data keeps decrypting.
+import CryptoJS from 'crypto-js'
+import { config } from '../../resources/redux'
+
+// Dynamic require so the bundle does not crash if the native module is missing (e.g. Expo Go).
+let SecureStore: typeof import('expo-secure-store') | null = null
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  SecureStore = require('expo-secure-store')
+} catch {
+  SecureStore = null
+}
+
+const GLOBAL_KEY: string = config.REDUX_ENCRYPT_KEY
+
+// expo-secure-store keys may only contain [A-Za-z0-9._-].
+function secureKeyName(userId: string): string {
+  return `oky_enc_${userId.replace(/[^A-Za-z0-9._-]/g, '')}`
+}
+
+const memoryCache = new Map<string, string>()
+
+// The key to encrypt/decrypt this account with: its per-account Keychain key if one exists,
+// otherwise the global key (legacy and migrated accounts).
+export async function getEncryptionKey(userId: string): Promise<string> {
+  const cached = memoryCache.get(userId)
+  if (cached) {
+    return cached
+  }
+  if (SecureStore) {
+    try {
+      const stored = await SecureStore.getItemAsync(secureKeyName(userId))
+      if (stored) {
+        memoryCache.set(userId, stored)
+        return stored
+      }
+    } catch {
+      // fall through to the global key
+    }
+  }
+  return GLOBAL_KEY
+}
+
+// Generate and persist a fresh per-account key in the Keychain. Called when an account is created.
+export async function createEncryptionKey(userId: string): Promise<string> {
+  const key = CryptoJS.lib.WordArray.random(32).toString(CryptoJS.enc.Hex)
+  memoryCache.set(userId, key)
+  if (SecureStore) {
+    try {
+      await SecureStore.setItemAsync(secureKeyName(userId), key)
+    } catch {
+      // best effort; cached for this session at least
+    }
+  }
+  return key
+}
+
+export async function deleteEncryptionKey(userId: string): Promise<void> {
+  memoryCache.delete(userId)
+  if (SecureStore) {
+    try {
+      await SecureStore.deleteItemAsync(secureKeyName(userId))
+    } catch {
+      // already gone
+    }
+  }
+}

--- a/app/src/services/auth/encryptionKeys.ts
+++ b/app/src/services/auth/encryptionKeys.ts
@@ -23,39 +23,99 @@ function secureKeyName(userId: string): string {
 
 const memoryCache = new Map<string, string>()
 
+// Thrown when an account is known to have its own Keychain key but that key cannot be read.
+// Callers must NOT fall back to the global key in this case: doing so would rehydrate the
+// account's correctly-encrypted blob to blank and then overwrite it. Instead the account should
+// be treated as temporarily unopenable (fall back to the logged-out context) until the key reads.
+export class EncryptionKeyUnavailableError extends Error {
+  constructor(userId: string) {
+    super(`encryption key unavailable for ${userId}`)
+    this.name = 'EncryptionKeyUnavailableError'
+  }
+}
+
+// Does the registry record this account as having its own durable Keychain key? Lazy-required to
+// avoid the encryptionKeys -> registry -> credentialVault -> encryptionKeys import cycle.
+async function accountExpectsOwnKey(userId: string): Promise<boolean> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getUser } = require('../userMetadata/registry') as {
+      getUser: (id: string) => Promise<{ hasEncryptionKey?: boolean } | null>
+    }
+    const account = await getUser(userId)
+    return account?.hasEncryptionKey === true
+  } catch {
+    return false
+  }
+}
+
 // The key to encrypt/decrypt this account with: its per-account Keychain key if one exists,
-// otherwise the global key (legacy and migrated accounts).
+// otherwise the global key (legacy and migrated accounts). Crucially, a *thrown* Keychain read
+// (or a missing key) for an account that is supposed to have its own key is treated as an error,
+// never as "use the global key" — silently using the wrong key destroys that account's data.
 export async function getEncryptionKey(userId: string): Promise<string> {
   const cached = memoryCache.get(userId)
   if (cached) {
     return cached
   }
+  const expectsOwnKey = await accountExpectsOwnKey(userId)
   if (SecureStore) {
+    let stored: string | null
     try {
-      const stored = await SecureStore.getItemAsync(secureKeyName(userId))
-      if (stored) {
-        memoryCache.set(userId, stored)
-        return stored
+      stored = await SecureStore.getItemAsync(secureKeyName(userId))
+    } catch (err) {
+      if (expectsOwnKey) {
+        throw new EncryptionKeyUnavailableError(userId)
       }
-    } catch {
-      // fall through to the global key
+      // Legacy account with no per-account key: the read error is irrelevant, the global key is
+      // the correct one.
+      return GLOBAL_KEY
     }
+    if (stored) {
+      memoryCache.set(userId, stored)
+      return stored
+    }
+    // No stored key. For a legacy account that is expected; for an own-key account it means the
+    // key vanished, and falling back would corrupt — refuse.
+    if (expectsOwnKey) {
+      throw new EncryptionKeyUnavailableError(userId)
+    }
+    return GLOBAL_KEY
+  }
+  if (expectsOwnKey) {
+    throw new EncryptionKeyUnavailableError(userId)
   }
   return GLOBAL_KEY
 }
 
-// Generate and persist a fresh per-account key in the Keychain. Called when an account is created.
-export async function createEncryptionKey(userId: string): Promise<string> {
+export interface CreatedEncryptionKey {
+  key: string
+  // The Keychain native module is present on this device.
+  secureStoreAvailable: boolean
+  // The key was durably written to and read back from the Keychain (so it survives a restart).
+  persisted: boolean
+}
+
+// Generate a fresh per-account key. When the Keychain is available the key is written and read
+// back to confirm it persisted (a non-durable key would make the account's data unrecoverable on
+// restart); the caller decides whether to proceed. When the Keychain is unavailable the account
+// will consistently use the global key, so the random key is neither cached nor persisted.
+export async function createEncryptionKey(userId: string): Promise<CreatedEncryptionKey> {
   const key = CryptoJS.lib.WordArray.random(32).toString(CryptoJS.enc.Hex)
-  memoryCache.set(userId, key)
-  if (SecureStore) {
-    try {
-      await SecureStore.setItemAsync(secureKeyName(userId), key)
-    } catch {
-      // best effort; cached for this session at least
-    }
+  if (!SecureStore) {
+    return { key, secureStoreAvailable: false, persisted: false }
   }
-  return key
+  try {
+    await SecureStore.setItemAsync(secureKeyName(userId), key)
+    const readback = await SecureStore.getItemAsync(secureKeyName(userId))
+    if (readback === key) {
+      memoryCache.set(userId, key)
+      return { key, secureStoreAvailable: true, persisted: true }
+    }
+  } catch {
+    // fall through: not persisted
+  }
+  return { key, secureStoreAvailable: true, persisted: false }
 }
 
 export async function deleteEncryptionKey(userId: string): Promise<void> {

--- a/app/src/services/auth/hashUtils.ts
+++ b/app/src/services/auth/hashUtils.ts
@@ -1,0 +1,36 @@
+// Pure-JS password / secret-answer hashing for offline verification.
+// PBKDF2-SHA256 over crypto-js (already a dependency). No native module, so this works
+// on the existing dev build without a rebuild. Iteration count is a deliberate tradeoff:
+// high enough to slow brute force, low enough to not freeze the JS thread on a phone.
+// Tune ITERATIONS after measuring on-device if signup/login feels sluggish.
+import CryptoJS from 'crypto-js'
+
+const ITERATIONS = 10000
+const KEY_SIZE_WORDS = 256 / 32
+const SALT_BYTES = 16
+
+export interface Hashed {
+  hash: string
+  salt: string
+}
+
+function derive(secret: string, saltHex: string): string {
+  return CryptoJS.PBKDF2(secret, CryptoJS.enc.Hex.parse(saltHex), {
+    keySize: KEY_SIZE_WORDS,
+    iterations: ITERATIONS,
+    hasher: CryptoJS.algo.SHA256,
+  }).toString(CryptoJS.enc.Hex)
+}
+
+export function hashSecret(secret: string): Hashed {
+  const salt = CryptoJS.lib.WordArray.random(SALT_BYTES).toString(CryptoJS.enc.Hex)
+  return { hash: derive(secret, salt), salt }
+}
+
+export function verifySecret(secret: string, hash: string, salt: string): boolean {
+  if (!hash || !salt) {
+    return false
+  }
+  const derived = derive(secret, salt)
+  return derived.length === hash.length && derived === hash
+}

--- a/app/src/services/auth/pendingLocale.ts
+++ b/app/src/services/auth/pendingLocale.ts
@@ -1,0 +1,16 @@
+// A language the user explicitly picked on the logged-out auth screen (the anon store). Language
+// is stored per account, so without this an account's own saved language would always win on
+// login and the deliberate pick on the login screen would be discarded. This holds that pick (in
+// memory, for the session) so the next login/switch can apply it to the account being opened.
+let pending: string | null = null
+
+export function setPendingLocale(locale: string): void {
+  pending = locale
+}
+
+// Returns the pending locale once and clears it (so it applies to a single login/switch only).
+export function consumePendingLocale(): string | null {
+  const locale = pending
+  pending = null
+  return locale
+}

--- a/app/src/services/deviceId.ts
+++ b/app/src/services/deviceId.ts
@@ -1,0 +1,32 @@
+// Stable per-install device id, used to scope the per-device account limit.
+// Deliberately lives in its own file rather than services/device.ts: resources/redux.ts
+// imports IS_IOS from services/device.ts, so adding AsyncStorage logic there would create
+// an import cycle (resources/redux -> device -> AsyncStorage).
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { v4 as uuidv4 } from 'uuid'
+import { DEVICE_ID_KEY } from './storage/storageKeys'
+
+let cached: string | null = null
+
+export async function getDeviceId(): Promise<string> {
+  if (cached) {
+    return cached
+  }
+  try {
+    const existing = await AsyncStorage.getItem(DEVICE_ID_KEY)
+    if (existing) {
+      cached = existing
+      return existing
+    }
+  } catch {
+    // fall through and generate a fresh id
+  }
+  const generated = uuidv4()
+  cached = generated
+  try {
+    await AsyncStorage.setItem(DEVICE_ID_KEY, generated)
+  } catch {
+    // best effort; the cached value is still stable for this session
+  }
+  return generated
+}

--- a/app/src/services/migration/legacyMigration.ts
+++ b/app/src/services/migration/legacyMigration.ts
@@ -1,0 +1,87 @@
+// One-time migration from the legacy single-user store ('persist:primary') to the per-user
+// model. Copies the existing user's encrypted blob to their 'user:{id}:data' key, registers
+// them as the active account, and seeds their credential vault from the plaintext password
+// and secret answer that the legacy auth slice stored. Runs once, never blocks boot on error,
+// and never loses the existing user's data (the legacy key is retained for rollback).
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import CryptoJS from 'crypto-js'
+import { config } from '../../resources/redux'
+import { LEGACY_PERSIST_KEY, userDataStorageKey, MIGRATION_FLAG_KEY } from '../storage/storageKeys'
+import { addUser, listUsers, setActiveUser } from '../userMetadata/registry'
+import { getDeviceId } from '../deviceId'
+import { saveCredential } from '../auth/credentialVault'
+
+interface LegacyAuthSlice {
+  appToken?: string | null
+  user?: {
+    id?: string
+    name?: string
+    password?: string
+    secretAnswer?: string
+  } | null
+}
+
+function decryptSlice(cipher: string): LegacyAuthSlice | null {
+  try {
+    const text = CryptoJS.AES.decrypt(cipher, config.REDUX_ENCRYPT_KEY).toString(CryptoJS.enc.Utf8)
+    return text ? (JSON.parse(text) as LegacyAuthSlice) : null
+  } catch {
+    return null
+  }
+}
+
+export async function runLegacyMigration(): Promise<void> {
+  try {
+    if (await AsyncStorage.getItem(MIGRATION_FLAG_KEY)) {
+      return
+    }
+    const legacyRaw = await AsyncStorage.getItem(LEGACY_PERSIST_KEY)
+    const alreadyHaveUsers = (await listUsers()).length > 0
+
+    if (!legacyRaw || alreadyHaveUsers) {
+      // Fresh install, or accounts already exist: nothing to migrate.
+      await AsyncStorage.setItem(MIGRATION_FLAG_KEY, '1')
+      return
+    }
+
+    const blob = JSON.parse(legacyRaw) as Record<string, string>
+    const auth = blob.auth ? decryptSlice(blob.auth) : null
+    const user = auth && auth.user
+    if (!user || !user.id || !user.name) {
+      // No usable account in the legacy blob; treat the device as fresh.
+      await AsyncStorage.setItem(MIGRATION_FLAG_KEY, '1')
+      return
+    }
+
+    const deviceId = await getDeviceId()
+    // The legacy blob is already encrypted with the same key the per-user store uses, so the
+    // new store rehydrates it directly. Copy it verbatim to the user-scoped key.
+    await AsyncStorage.setItem(userDataStorageKey(user.id), legacyRaw)
+
+    await addUser({
+      id: user.id,
+      serverId: user.id,
+      name: user.name,
+      deviceId,
+      isPendingSync: false,
+      appToken: auth?.appToken ?? null,
+    })
+    await setActiveUser(user.id)
+
+    if (user.password) {
+      // The legacy account was created online, so it is already synced; no plaintext is kept
+      // for re-sync, only the hashes for offline login and the secret answer for reset.
+      await saveCredential({
+        userId: user.id,
+        password: user.password,
+        secretAnswer: user.secretAnswer ?? null,
+        keepPlainForSync: false,
+      })
+    }
+
+    await AsyncStorage.setItem(MIGRATION_FLAG_KEY, '1')
+  } catch {
+    // Never block boot on a migration failure; the app falls back to a clean account-selection
+    // state and the legacy key is left intact for a later retry.
+  }
+}

--- a/app/src/services/migration/legacyMigration.ts
+++ b/app/src/services/migration/legacyMigration.ts
@@ -18,6 +18,9 @@ interface LegacyAuthSlice {
     name?: string
     password?: string
     secretAnswer?: string
+    // Legacy offline-created accounts (a failed online signup) were stored as guests with no
+    // server token; they still need to be registered on the server.
+    isGuest?: boolean
   } | null
 }
 
@@ -54,28 +57,34 @@ export async function runLegacyMigration(): Promise<void> {
     }
 
     const deviceId = await getDeviceId()
+    // A legacy guest (offline-created) account has no server token and must still sync; an
+    // online-created account already has its token and is synced.
+    const isGuest = user.isGuest === true || !auth?.appToken
     // The legacy blob is already encrypted with the same key the per-user store uses, so the
     // new store rehydrates it directly. Copy it verbatim to the user-scoped key.
     await AsyncStorage.setItem(userDataStorageKey(user.id), legacyRaw)
 
     await addUser({
       id: user.id,
-      serverId: user.id,
+      serverId: isGuest ? null : user.id,
       name: user.name,
       deviceId,
-      isPendingSync: false,
+      isPendingSync: isGuest,
       appToken: auth?.appToken ?? null,
+      // Migrated accounts keep using the global key (their blob is already encrypted with it).
+      hasEncryptionKey: false,
     })
     await setActiveUser(user.id)
 
     if (user.password) {
-      // The legacy account was created online, so it is already synced; no plaintext is kept
-      // for re-sync, only the hashes for offline login and the secret answer for reset.
+      // Keep the plaintext for re-sync only when the account still needs to register on the
+      // server (a guest); otherwise store only the hashes for offline login plus the secret
+      // answer for reset.
       await saveCredential({
         userId: user.id,
         password: user.password,
         secretAnswer: user.secretAnswer ?? null,
-        keepPlainForSync: false,
+        keepPlainForSync: isGuest,
       })
     }
 

--- a/app/src/services/storage/storageKeys.ts
+++ b/app/src/services/storage/storageKeys.ts
@@ -1,0 +1,26 @@
+// Single source of truth for every multi-user storage key.
+// Nothing else in the app should hardcode these strings.
+
+// The legacy single-user redux-persist blob, written before multi-user existed.
+export const LEGACY_PERSIST_KEY = 'persist:primary'
+
+// The redux-persist config "key" for a given user (what persistReducer is configured with).
+export const userDataConfigKey = (userId: string): string => `user:${userId}:data`
+
+// The actual AsyncStorage key redux-persist writes under for that config key.
+export const userDataStorageKey = (userId: string): string => `persist:user:${userId}:data`
+
+// The account registry: list of local accounts plus the active user id.
+export const USERS_REGISTRY_KEY = 'metadata:oky:users'
+
+// Encrypted per-user credential record (hashes plus sync secrets).
+export const credentialKey = (userId: string): string => `metadata:oky:cred:${userId}`
+
+// Stable per-install device id, used to scope the per-device account limit.
+export const DEVICE_ID_KEY = 'metadata:oky:deviceId'
+
+// One-time legacy migration completion flag.
+export const MIGRATION_FLAG_KEY = 'metadata:oky:migrated'
+
+// Placeholder id used before any real account exists on the device.
+export const ANON_USER_ID = '__anon__'

--- a/app/src/services/sync/syncManager.ts
+++ b/app/src/services/sync/syncManager.ts
@@ -1,0 +1,92 @@
+// Background sync for accounts created offline. When the device is online (and whenever the
+// active account changes), the active account, if still pending sync, is registered on the
+// server via the existing signup endpoint, carrying its deviceId. Event-based via NetInfo plus
+// an attempt on every account switch; no polling. Non-active pending accounts sync when they
+// next become active and online.
+import NetInfo from '@react-native-community/netinfo'
+import { getActiveBundle, subscribeBundle } from '../../redux/storeManager'
+import { ANON_USER_ID } from '../storage/storageKeys'
+import * as registry from '../userMetadata/registry'
+import { getSyncSecrets, clearSyncSecrets } from '../auth/credentialVault'
+import { getDeviceId } from '../deviceId'
+import { httpClient } from '../HttpClient'
+import { loginSuccess } from '../../redux/actions'
+
+let syncing = false
+
+export async function syncActiveAccount(): Promise<void> {
+  if (syncing) {
+    return
+  }
+  const bundle = getActiveBundle()
+  if (!bundle || bundle.userId === ANON_USER_ID) {
+    return
+  }
+
+  const account = await registry.getUser(bundle.userId)
+  if (!account || !account.isPendingSync) {
+    return
+  }
+
+  const net = await NetInfo.fetch().catch(() => ({ isConnected: false }))
+  if (!net.isConnected) {
+    return
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const user = (bundle.store.getState() as any)?.auth?.user
+  // The API rejects account creation when country is unset / '00' (old-variant guard).
+  if (!user || !user.country || user.country === '00') {
+    return
+  }
+
+  syncing = true
+  try {
+    const secrets = await getSyncSecrets(account.id)
+    const deviceId = await getDeviceId()
+    const response = await httpClient.signup({
+      name: user.name,
+      password: secrets.password ?? user.password,
+      dateOfBirth: user.dateOfBirth,
+      gender: user.gender,
+      location: user.location,
+      country: user.country,
+      province: user.province,
+      secretQuestion: user.secretQuestion,
+      secretAnswer: secrets.secretAnswer ?? user.secretAnswer,
+      dateSignedUp: user.dateSignedUp,
+      metadata: user.metadata,
+      preferredId: account.id,
+      deviceId,
+    })
+
+    if (response && response.appToken && response.user && response.user.id) {
+      // The local id stays the store key; the server id is recorded separately in the registry.
+      await registry.markSynced(account.id, response.user.id, response.appToken)
+      await clearSyncSecrets(account.id)
+      bundle.store.dispatch(loginSuccess({ appToken: response.appToken, user }))
+    }
+  } catch {
+    // Leave the account pending; it retries on the next online event or account switch.
+  } finally {
+    syncing = false
+  }
+}
+
+// Start watching for opportunities to sync: once now, on every account switch, and whenever the
+// device comes back online. Returns an unsubscribe function.
+export function startSyncWatcher(): () => void {
+  void syncActiveAccount()
+  const unsubscribeBundle = subscribeBundle(() => {
+    void syncActiveAccount()
+  })
+  const unsubscribeNet = NetInfo.addEventListener((state) => {
+    if (state.isConnected) {
+      void syncActiveAccount()
+    }
+  })
+  return () => {
+    unsubscribeBundle()
+    unsubscribeNet()
+  }
+}

--- a/app/src/services/sync/syncManager.ts
+++ b/app/src/services/sync/syncManager.ts
@@ -15,33 +15,36 @@ import { loginSuccess } from '../../redux/actions'
 let syncing = false
 
 export async function syncActiveAccount(): Promise<void> {
+  // Set the single-flight guard synchronously, before any await, so two triggers firing close
+  // together (e.g. the initial run plus a NetInfo online event) cannot both pass the check and
+  // double-register the same account.
   if (syncing) {
     return
   }
-  const bundle = getActiveBundle()
-  if (!bundle || bundle.userId === ANON_USER_ID) {
-    return
-  }
-
-  const account = await registry.getUser(bundle.userId)
-  if (!account || !account.isPendingSync) {
-    return
-  }
-
-  const net = await NetInfo.fetch().catch(() => ({ isConnected: false }))
-  if (!net.isConnected) {
-    return
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const user = (bundle.store.getState() as any)?.auth?.user
-  // The API rejects account creation when country is unset / '00' (old-variant guard).
-  if (!user || !user.country || user.country === '00') {
-    return
-  }
-
   syncing = true
   try {
+    const bundle = getActiveBundle()
+    if (!bundle || bundle.userId === ANON_USER_ID) {
+      return
+    }
+
+    const account = await registry.getUser(bundle.userId)
+    if (!account || !account.isPendingSync) {
+      return
+    }
+
+    const net = await NetInfo.fetch().catch(() => ({ isConnected: false }))
+    if (!net.isConnected) {
+      return
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const user = (bundle.store.getState() as any)?.auth?.user
+    // The API rejects account creation when country is unset / '00' (old-variant guard).
+    if (!user || !user.country || user.country === '00') {
+      return
+    }
+
     const secrets = await getSyncSecrets(account.id)
     const deviceId = await getDeviceId()
     const response = await httpClient.signup({
@@ -64,7 +67,13 @@ export async function syncActiveAccount(): Promise<void> {
       // The local id stays the store key; the server id is recorded separately in the registry.
       await registry.markSynced(account.id, response.user.id, response.appToken)
       await clearSyncSecrets(account.id)
-      bundle.store.dispatch(loginSuccess({ appToken: response.appToken, user }))
+      // Only reflect the token in the live store if this account is still the active one — the
+      // user may have switched (or logged out) during the network round-trip, which would have
+      // torn down the captured store.
+      const current = getActiveBundle()
+      if (current && current.userId === account.id) {
+        current.store.dispatch(loginSuccess({ appToken: response.appToken, user }))
+      }
     }
   } catch {
     // Leave the account pending; it retries on the next online event or account switch.

--- a/app/src/services/userMetadata/index.ts
+++ b/app/src/services/userMetadata/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './registry'

--- a/app/src/services/userMetadata/registry.ts
+++ b/app/src/services/userMetadata/registry.ts
@@ -1,0 +1,127 @@
+// The account registry: the list of local accounts plus the active user id, kept in
+// AsyncStorage under a single key. All writes go through a serialized queue so concurrent
+// mutations (e.g. signup racing a sync) cannot clobber each other.
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { USERS_REGISTRY_KEY } from '../storage/storageKeys'
+import { deleteCredential } from '../auth/credentialVault'
+import { MAX_ACCOUNTS_PER_DEVICE, RegisteredUser, UsersRegistry } from './types'
+
+export const MAX_ACCOUNTS_ERROR = 'MAX_ACCOUNTS'
+
+let writeChain: Promise<unknown> = Promise.resolve()
+
+async function load(): Promise<UsersRegistry> {
+  try {
+    const raw = await AsyncStorage.getItem(USERS_REGISTRY_KEY)
+    if (!raw) {
+      return { users: [], activeUserId: null }
+    }
+    const parsed = JSON.parse(raw) as UsersRegistry
+    return { users: parsed.users || [], activeUserId: parsed.activeUserId ?? null }
+  } catch {
+    return { users: [], activeUserId: null }
+  }
+}
+
+// Serialize read-modify-write so concurrent callers never lose an update.
+function mutate<T>(fn: (reg: UsersRegistry) => { next: UsersRegistry; result: T }): Promise<T> {
+  const run = writeChain.then(async () => {
+    const reg = await load()
+    const { next, result } = fn(reg)
+    await AsyncStorage.setItem(USERS_REGISTRY_KEY, JSON.stringify(next))
+    return result
+  })
+  writeChain = run.then(
+    () => undefined,
+    () => undefined,
+  )
+  return run
+}
+
+export async function listUsers(): Promise<RegisteredUser[]> {
+  return (await load()).users
+}
+
+export async function getActiveUserId(): Promise<string | null> {
+  return (await load()).activeUserId
+}
+
+export async function getUser(id: string): Promise<RegisteredUser | null> {
+  return (await load()).users.find((u) => u.id === id) ?? null
+}
+
+export async function findUserByName(name: string): Promise<RegisteredUser | null> {
+  const target = name.trim().toLowerCase()
+  return (await load()).users.find((u) => u.name.trim().toLowerCase() === target) ?? null
+}
+
+export async function userCount(): Promise<number> {
+  return (await load()).users.length
+}
+
+export async function addUser(
+  user: Omit<RegisteredUser, 'isActive' | 'createdAt'> & { createdAt?: string },
+): Promise<RegisteredUser> {
+  return mutate((reg) => {
+    const exists = reg.users.some((u) => u.id === user.id)
+    if (!exists && reg.users.length >= MAX_ACCOUNTS_PER_DEVICE) {
+      throw new Error(MAX_ACCOUNTS_ERROR)
+    }
+    const record: RegisteredUser = {
+      ...user,
+      isActive: false,
+      createdAt: user.createdAt ?? new Date().toISOString(),
+    }
+    const others = reg.users.filter((u) => u.id !== user.id)
+    return { next: { ...reg, users: [...others, record] }, result: record }
+  })
+}
+
+export async function updateUser(id: string, patch: Partial<RegisteredUser>): Promise<void> {
+  await mutate((reg) => ({
+    next: { ...reg, users: reg.users.map((u) => (u.id === id ? { ...u, ...patch } : u)) },
+    result: undefined,
+  }))
+}
+
+export async function setActiveUser(id: string | null): Promise<void> {
+  await mutate((reg) => ({
+    next: {
+      activeUserId: id,
+      users: reg.users.map((u) => ({
+        ...u,
+        isActive: u.id === id,
+        lastActiveAt: u.id === id ? new Date().toISOString() : u.lastActiveAt,
+      })),
+    },
+    result: undefined,
+  }))
+}
+
+export async function markSynced(
+  id: string,
+  serverId: string,
+  appToken?: string | null,
+): Promise<void> {
+  await updateUser(id, { isPendingSync: false, serverId, appToken: appToken ?? null })
+}
+
+export async function markPendingDelete(id: string): Promise<void> {
+  await updateUser(id, { isPendingDelete: true })
+}
+
+// Fully remove an account: registry entry, its encrypted per-user store blob, and its
+// credentials. purgeUserStorage is lazy-required to avoid an import cycle with storeManager.
+export async function removeUser(id: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { purgeUserStorage } = require('../../redux/storeManager') as {
+    purgeUserStorage: (userId: string) => Promise<void>
+  }
+  await purgeUserStorage(id)
+  await deleteCredential(id)
+  await mutate((reg) => {
+    const users = reg.users.filter((u) => u.id !== id)
+    const activeUserId = reg.activeUserId === id ? null : reg.activeUserId
+    return { next: { users, activeUserId }, result: undefined }
+  })
+}

--- a/app/src/services/userMetadata/types.ts
+++ b/app/src/services/userMetadata/types.ts
@@ -11,6 +11,11 @@ export interface RegisteredUser {
   isActive: boolean
   // True while the account exists only locally and still needs to be registered on the server.
   isPendingSync: boolean
+  // True when this account has its own durable per-account key in the Keychain. Legacy/migrated
+  // accounts (and accounts created where the Keychain was unavailable) use the global key, so this
+  // is false/undefined for them. Used to refuse falling back to the global key for an account that
+  // actually has its own key, which would otherwise decrypt to blank and overwrite the real data.
+  hasEncryptionKey?: boolean
   // True when an online-synced account was deleted offline and the server delete is still pending.
   isPendingDelete?: boolean
   appToken?: string | null

--- a/app/src/services/userMetadata/types.ts
+++ b/app/src/services/userMetadata/types.ts
@@ -1,0 +1,24 @@
+export const MAX_ACCOUNTS_PER_DEVICE = 3
+
+export interface RegisteredUser {
+  // Immutable local id. Used to key the per-user persisted store and credentials.
+  // Never changes, even after the account syncs and the server assigns its own id.
+  id: string
+  // Server-assigned id, recorded after a successful sync. May differ from the local id.
+  serverId?: string | null
+  name: string
+  deviceId: string
+  isActive: boolean
+  // True while the account exists only locally and still needs to be registered on the server.
+  isPendingSync: boolean
+  // True when an online-synced account was deleted offline and the server delete is still pending.
+  isPendingDelete?: boolean
+  appToken?: string | null
+  createdAt: string
+  lastActiveAt?: string | null
+}
+
+export interface UsersRegistry {
+  users: RegisteredUser[]
+  activeUserId: string | null
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3012,6 +3012,11 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/crypto-js@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.2.2.tgz#771c4a768d94eb5922cc202a3009558204df0cea"
+  integrity sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.9"
   resolved "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -5015,6 +5015,11 @@ expo-screen-orientation@~9.0.9:
   resolved "https://registry.yarnpkg.com/expo-screen-orientation/-/expo-screen-orientation-9.0.9.tgz#74ed82582006f72106b7165512cdfc01367433ba"
   integrity sha512-UTU745XoqBvQJkZ820GTfMuOxlkppYqaeQ+x0wdu44cyrZiZugqe+egFF2+zC+SaxgAltU5EuO8GIj9xSF+YMw==
 
+expo-secure-store@~15.0.8:
+  version "15.0.8"
+  resolved "https://registry.yarnpkg.com/expo-secure-store/-/expo-secure-store-15.0.8.tgz#678065599bb76061b5a85b15b9426bf7a11089ae"
+  integrity sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==
+
 expo-server@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/expo-server/-/expo-server-1.0.6.tgz#a821c55dd3f9f3f9bce0ba70d81bbc9fcc360ee8"

--- a/packages/api/__tests__/application/oky/OkyUserApplicationService.test.ts
+++ b/packages/api/__tests__/application/oky/OkyUserApplicationService.test.ts
@@ -69,7 +69,7 @@ describe('OkyUserApplicationService', () => {
       ;(okyUserRepository.save as jest.Mock).mockResolvedValue('someValue')
 
       const command: SignupCommand = {
-        preferredId: '123',
+        preferredId: '123e4567-e89b-42d3-a456-426614174000',
         name: 'aaa',
         plainPassword: 'aaa',
         secretQuestion: 'favourite_actor',
@@ -93,7 +93,7 @@ describe('OkyUserApplicationService', () => {
         // Simulate an existing user
       })
       const command: SignupCommand = {
-        preferredId: '123',
+        preferredId: '123e4567-e89b-42d3-a456-426614174000',
         name: 'aaa',
         plainPassword: 'aaa',
         secretQuestion: 'favourite_actor',
@@ -146,7 +146,7 @@ describe('OkyUserApplicationService', () => {
       ;(okyUserRepository.save as jest.Mock).mockResolvedValue(mockOkyUser)
 
       const command: SignupCommand = {
-        preferredId: '123',
+        preferredId: '123e4567-e89b-42d3-a456-426614174000',
         name: 'aaa',
         plainPassword: 'aaa',
         secretQuestion: 'favourite_actor',

--- a/packages/api/src/application/oky/OkyUserApplicationService.ts
+++ b/packages/api/src/application/oky/OkyUserApplicationService.ts
@@ -48,6 +48,7 @@ export class OkyUserApplicationService {
     dateAccountSaved,
     metadata,
     avatar,
+    deviceId,
   }: SignupCommand) {
     const id = preferredId || (await this.okyUserRepository.nextIdentity())
     if (await this.okyUserRepository.byId(id)) {
@@ -74,6 +75,7 @@ export class OkyUserApplicationService {
       dateAccountSaved,
       metadata,
       avatar,
+      deviceId,
     })
     return this.okyUserRepository.save(user)
   }

--- a/packages/api/src/application/oky/OkyUserApplicationService.ts
+++ b/packages/api/src/application/oky/OkyUserApplicationService.ts
@@ -50,8 +50,24 @@ export class OkyUserApplicationService {
     avatar,
     deviceId,
   }: SignupCommand) {
+    // Reject a malformed preferredId at the boundary with a clean 400 rather than letting a
+    // non-uuid reach the uuid primary-key column and surface as an opaque 500. (Belt-and-suspenders
+    // alongside SignupRequest's @IsUUID, since request-body validation is not enforced here.)
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    if (preferredId && !UUID_RE.test(preferredId)) {
+      throw new HttpError(400, `preferredId must be a valid UUID`)
+    }
     const id = preferredId || (await this.okyUserRepository.nextIdentity())
-    if (await this.okyUserRepository.byId(id)) {
+    const existingById = await this.okyUserRepository.byId(id)
+    if (existingById) {
+      // Idempotent re-sync: an offline-created account retries with its own preferredId after a
+      // lost/dropped first response. If the supplied password matches the existing row, return it
+      // (the controller re-issues a token) instead of erroring, so a dropped response no longer
+      // wedges the account in a permanent failing-retry loop. A mismatched password is a genuine
+      // id conflict and still fails.
+      if (preferredId && (await existingById.verifyPassword(plainPassword))) {
+        return existingById
+      }
       throw new HttpError(400, `User with this id already exists`)
     }
 

--- a/packages/api/src/application/oky/commands/SignupCommand.ts
+++ b/packages/api/src/application/oky/commands/SignupCommand.ts
@@ -15,4 +15,5 @@ export interface SignupCommand {
   dateAccountSaved: string
   metadata: UserMetadata
   avatar?: AvatarConfig | null
+  deviceId?: string
 }

--- a/packages/api/src/application/oky/commands/SignupCommand.ts
+++ b/packages/api/src/application/oky/commands/SignupCommand.ts
@@ -1,7 +1,7 @@
 import { UserMetadata, AvatarConfig } from 'domain/oky/OkyUser'
 
 export interface SignupCommand {
-  preferredId: string
+  preferredId?: string
   name: string
   dateOfBirth: Date
   gender: 'Male' | 'Female' | 'Other'

--- a/packages/api/src/domain/oky/OkyUser.ts
+++ b/packages/api/src/domain/oky/OkyUser.ts
@@ -19,6 +19,7 @@ interface OkyUserProps {
   dateAccountSaved: string
   metadata: UserMetadata
   avatar: AvatarConfig | null
+  deviceId?: string
 }
 
 export interface AvatarConfig {
@@ -92,6 +93,9 @@ export class OkyUser {
   @Column({ name: 'avatar', type: 'json', nullable: true, default: null })
   private avatar: AvatarConfig | null
 
+  @Column({ name: 'deviceId', type: 'varchar', nullable: true })
+  private deviceId: string | undefined
+
   private constructor(props?: OkyUserProps) {
     if (props !== undefined) {
       const {
@@ -108,6 +112,7 @@ export class OkyUser {
         dateAccountSaved,
         metadata,
         avatar,
+        deviceId,
       } = props
 
       this.id = id
@@ -123,6 +128,7 @@ export class OkyUser {
       this.dateSignedUp = dateSignedUp
       this.dateAccountSaved = dateAccountSaved
       this.metadata = metadata
+      this.deviceId = deviceId
       // Ensure customAvatarUnlocked is set to false if not provided
       this.avatar = {
         ...avatar,
@@ -146,6 +152,7 @@ export class OkyUser {
     dateAccountSaved,
     metadata,
     avatar = null,
+    deviceId,
   }: {
     id: string
     name: string
@@ -161,6 +168,7 @@ export class OkyUser {
     dateAccountSaved: string
     metadata: UserMetadata
     avatar?: AvatarConfig | null
+    deviceId?: string
   }): Promise<OkyUser> {
     if (!id) {
       throw new Error(`The user id must be provided`)
@@ -188,6 +196,7 @@ export class OkyUser {
       dateAccountSaved,
       metadata,
       avatar,
+      deviceId,
     })
   }
 
@@ -300,6 +309,10 @@ export class OkyUser {
 
   public getAvatar() {
     return this.avatar
+  }
+
+  public getDeviceId() {
+    return this.deviceId
   }
 
   public formatAvatar(avatar: AvatarConfig | null) {

--- a/packages/api/src/interfaces/api/controllers/account/AccountController.ts
+++ b/packages/api/src/interfaces/api/controllers/account/AccountController.ts
@@ -54,6 +54,7 @@ export class AccountController {
       dateSignedUp,
       metadata,
       avatar,
+      deviceId,
     }: SignupRequest,
   ) {
     if (country === null || country === '00') {
@@ -76,6 +77,7 @@ export class AccountController {
       dateAccountSaved: new Date().toISOString(),
       metadata,
       avatar,
+      deviceId,
     })
 
     return this.signTokenResponse(user)

--- a/packages/api/src/interfaces/api/controllers/account/requests/SignupRequest.ts
+++ b/packages/api/src/interfaces/api/controllers/account/requests/SignupRequest.ts
@@ -47,4 +47,6 @@ export class SignupRequest {
   public readonly metadata?: UserMetadata
 
   public readonly avatar?: AvatarConfig | null
+
+  public readonly deviceId?: string
 }

--- a/packages/api/src/interfaces/api/controllers/account/requests/SignupRequest.ts
+++ b/packages/api/src/interfaces/api/controllers/account/requests/SignupRequest.ts
@@ -1,9 +1,22 @@
-import { IsNotEmpty, MinLength, IsIn, IsDateString } from 'class-validator'
+import {
+  IsNotEmpty,
+  MinLength,
+  IsIn,
+  IsDateString,
+  IsOptional,
+  IsUUID,
+  IsString,
+  MaxLength,
+} from 'class-validator'
 import { UserMetadata, AvatarConfig } from 'domain/oky/OkyUser'
 const minNameLength = 3
 const minPasswordLength = 1
 export class SignupRequest {
-  public readonly preferredId: string
+  // Validated as a UUID so a malformed preferredId is rejected with a clean 400 at the boundary
+  // rather than blowing up as a 500 when it reaches the uuid primary-key column.
+  @IsOptional()
+  @IsUUID('4')
+  public readonly preferredId?: string
 
   @IsNotEmpty()
   @MinLength(minNameLength, {
@@ -48,5 +61,8 @@ export class SignupRequest {
 
   public readonly avatar?: AvatarConfig | null
 
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
   public readonly deviceId?: string
 }

--- a/sql/1780904416231-add-oky-user-device-id.sql
+++ b/sql/1780904416231-add-oky-user-device-id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oky_user
+ADD COLUMN IF NOT EXISTS "deviceId" character varying;


### PR DESCRIPTION
## 📌 Summary

Adds support for multiple offline user accounts on a single device, the capability PR #193 set out to deliver. Each account gets its own isolated, encrypted store, so accounts never share or overwrite each other's data, and the entire flow works with no network connection.

## 🔗 Ticket / Issue

* Supersedes: [Oky-period-tracker/periodtracker#193](https://github.com/Oky-period-tracker/periodtracker/pull/193) (Taking care of the multiple offline users part)

## ✅ Changes

* [x] Feature: per-account isolated encrypted stores; offline signup, login, account switching (a "Select a user" dropdown), delete, and forgot-password; full onboarding (avatar, theme, period survey) per account; background sync to the server when online; a backend deviceId column and migration.
* [x] Fix: logout no longer wipes the active account; the welcome intro no longer replays after logout; the post-signup onboarding survey (dropped during the refactor) is restored; a language picked on the auth screen carries through login and switch.
* [x] Refactor: account-changing operations moved to a service layer (accountFlows) outside the per-user saga; all store transitions serialized, and each store owns its saga.
* [ ] Docs
* [ ] Tests
* [x] Other: per-account Keychain encryption keys with a global-key fallback; a credential vault (PBKDF2 hashes plus AES-encrypted sync secrets); an account registry (max 3 per device); a one-time legacy single-user migration.

## 🧪 Testing

Verified on a physical Android device (SDK 54 build).

* Steps to reproduce:

1. Fresh install, create an account fully offline, go through onboarding (avatar, theme, period survey), and reach home.
2. Log out, create a second account, switch between them with the dropdown, and confirm each shows its own data.
3. Force-close and reopen, log back into each account, and confirm its data persisted.
4. Delete an account from Settings and confirm it is fully removed (registry entry, store blob, credentials) and the slot is freed.
5. With the server reachable, confirm an offline-created account registers itself (deviceId stored, same local and server id).

* ✅ Expected result: each account is fully isolated and persists across restarts, logout keeps data, onboarding seeds the prediction, and offline accounts sync once online.
* ❌ Bugs to watch out for: cross-account data bleed on a fast switch, an account failing to decrypt after a key read error, a new account skipping the period survey, language reverting after account creation. Each of these was covered by the review and fixes included here.

## 📸 Screenshots (if applicable)

A device recording of the offline flow is being attached separately.

https://github.com/user-attachments/assets/a69950a6-c804-4656-912d-b71c3ab57d53

## 📖 Notes for Reviewers

* Account-changing operations must stay in the accountFlows service layer, not the per-user saga, because switching tears down and rebuilds the active store (which cancels the saga that called it).
* Request-body validation is not enforced globally on the API (pre-existing), so preferredId is additionally guarded in the service layer.
* The global fallback key is the app's existing key, so legacy and migrated account blobs keep their existing at-rest protection and this introduces no regression for them.

---

### Checklist

* [x] Code follows style guidelines
* [x] Self-review completed
* [ ] Tests added/updated (manual device verification only; no automated tests added)
* [ ] Documentation updated
* [x] No sensitive info (keys, secrets, etc.) committed
