### PR TITLE
fix(cms): surface real push notification delivery status

### DIFF
--- a/packages/cms/src/controller/NotificationController.ts
+++ b/packages/cms/src/controller/NotificationController.ts
@@ -112,19 +112,9 @@ export class NotificationController {
       throw error
     }
 
+    let messageId: string
     try {
-      const messageId = await this.firebaseSend({ title, body: content, lang })
-
-      notification.status = NOTIFICATION_STATUS.SENT
-      await this.notificationRepository.save(notification)
-
-      logger.info('Notification sent and saved', {
-        id: notification.id,
-        title,
-        lang,
-        messageId,
-      })
-      return { ...notification, messageId }
+      messageId = await this.firebaseSend({ title, body: content, lang })
     } catch (error) {
       const outcomeUnknown = isDeliveryOutcomeUnknown(error)
       notification.status = outcomeUnknown
@@ -161,6 +151,28 @@ export class NotificationController {
       }
       return
     }
+
+    notification.status = NOTIFICATION_STATUS.SENT
+    try {
+      await this.notificationRepository.save(notification)
+    } catch (error) {
+      logger.error('NotificationController.save delivered but could not persist sent status', {
+        id: notification.id,
+        title,
+        lang,
+        messageId,
+        message: error?.message,
+        stack: error?.stack,
+      })
+    }
+
+    logger.info('Notification sent', {
+      id: notification.id,
+      title,
+      lang,
+      messageId,
+    })
+    return { ...notification, messageId }
   }
 
   async updatePermanentAlert(request: Request, response: Response, next: NextFunction) {

--- a/packages/cms/src/controller/NotificationController.ts
+++ b/packages/cms/src/controller/NotificationController.ts
@@ -7,6 +7,12 @@ import { env } from '../env'
 import { logger } from '../logger'
 import { withTimeout, DEFAULT_EXTERNAL_TIMEOUT } from '../helpers/timeout'
 import { withRetry } from '../helpers/retry'
+import {
+  NOTIFICATION_STATUS,
+  describeDeliveryError,
+  isDeliveryOutcomeUnknown,
+  isRetriableFirebaseError,
+} from '../helpers/notificationDelivery'
 
 export class NotificationController {
   private notificationRepository = getRepository(Notification)
@@ -16,7 +22,7 @@ export class NotificationController {
     return this.notificationRepository.findOne({
       where: {
         lang: request.params.lang,
-        status: 'sent',
+        status: NOTIFICATION_STATUS.SENT,
       },
     })
   }
@@ -61,30 +67,99 @@ export class NotificationController {
     }
   }
 
+  /**
+   * Broadcasts a notification and records what actually happened.
+   *
+   * The record is written *before* contacting Firebase so that a crash during
+   * the send can never leave a delivered alert with no trace in the CMS — an
+   * admin seeing nothing would simply send it again, notifying everyone twice.
+   * The row starts as `unknown` and is only promoted to `sent` once Firebase
+   * has confirmed it.
+   */
   async save(request: Request, response: Response, next: NextFunction) {
-    try {
-      const notificationToAdd = request.body
+    const lang = request.user.lang
+    const title = typeof request.body.title === 'string' ? request.body.title.trim() : ''
+    const content = typeof request.body.content === 'string' ? request.body.content.trim() : ''
 
-      await this.firebaseSend({
-        title: request.body.title,
-        body: request.body.content,
-        lang: request.user.lang,
-      })
-      notificationToAdd.date_sent = new Date().getTime()
-      notificationToAdd.status = 'sent'
-      notificationToAdd.lang = request.user.lang
-      await this.notificationRepository.save(notificationToAdd)
-      logger.info('Notification sent and saved', {
-        title: request.body.title,
-        lang: request.user.lang,
-      })
-      return notificationToAdd
+    if (!title || !content) {
+      if (!response.headersSent) {
+        response.status(400).send({
+          status: NOTIFICATION_STATUS.FAILED,
+          error: 'A title and a message are required to send a notification.',
+        })
+      }
+      return
+    }
+
+    let notification: Notification
+    try {
+      notification = await this.notificationRepository.save(
+        this.notificationRepository.create({
+          title,
+          content,
+          lang,
+          date_sent: String(Date.now()),
+          status: NOTIFICATION_STATUS.UNKNOWN,
+        }),
+      )
     } catch (error) {
-      logger.error('NotificationController.save failed', {
+      logger.error('NotificationController.save could not record the attempt', {
+        title,
+        lang,
         message: error?.message,
         stack: error?.stack,
       })
       throw error
+    }
+
+    try {
+      const messageId = await this.firebaseSend({ title, body: content, lang })
+
+      notification.status = NOTIFICATION_STATUS.SENT
+      await this.notificationRepository.save(notification)
+
+      logger.info('Notification sent and saved', {
+        id: notification.id,
+        title,
+        lang,
+        messageId,
+      })
+      return { ...notification, messageId }
+    } catch (error) {
+      const outcomeUnknown = isDeliveryOutcomeUnknown(error)
+      notification.status = outcomeUnknown
+        ? NOTIFICATION_STATUS.UNKNOWN
+        : NOTIFICATION_STATUS.FAILED
+
+      // Best effort: a failed status write must not hide the delivery error.
+      try {
+        await this.notificationRepository.save(notification)
+      } catch (writeError) {
+        logger.error('NotificationController.save could not persist the failed status', {
+          id: notification.id,
+          message: writeError?.message,
+          stack: writeError?.stack,
+        })
+      }
+
+      logger.error('NotificationController.save failed to deliver the notification', {
+        id: notification.id,
+        title,
+        lang,
+        topic: this.topicFor(lang),
+        status: notification.status,
+        message: error?.message,
+        stack: error?.stack,
+      })
+
+      // The requestTimeout middleware may already have answered with a 503.
+      if (!response.headersSent) {
+        response.status(502).send({
+          status: notification.status,
+          error: describeDeliveryError(error),
+        })
+      }
+      return
     }
   }
 
@@ -161,35 +236,43 @@ export class NotificationController {
     }
   }
 
-  private async firebaseSend({ title, body, lang }) {
+  private topicFor(lang: string) {
+    return `oky_${lang}_notifications`
+  }
+
+  /**
+   * Sends the message to the language topic and returns the Firebase message id.
+   * Throws when Firebase rejects the message or never answers.
+   */
+  private async firebaseSend({ title, body, lang }): Promise<string> {
+    const topic = this.topicFor(lang)
     const message = {
       notification: {
         title,
         body,
       },
-      topic: `oky_${lang}_notifications`,
+      topic,
     }
-    try {
-      const response = await withRetry(
-        () =>
-          withTimeout(
-            admin.messaging().send(message),
-            DEFAULT_EXTERNAL_TIMEOUT,
-            'Firebase notification send',
-          ),
-        { maxRetries: 2, baseDelay: 1000, label: 'Firebase send' },
-      )
-      logger.info('Firebase notification sent', {
-        messageId: response,
-        topic: `oky_${lang}_notifications`,
-      })
-    } catch (error) {
-      logger.error('Firebase notification failed', {
-        topic: `oky_${lang}_notifications`,
-        message: error?.message,
-        stack: error?.stack,
-      })
-      throw error
-    }
+
+    const messageId = await withRetry(
+      () =>
+        withTimeout(
+          admin.messaging().send(message),
+          DEFAULT_EXTERNAL_TIMEOUT,
+          'Firebase notification send',
+        ),
+      {
+        maxRetries: 2,
+        baseDelay: 1000,
+        label: 'Firebase send',
+        // A timed-out send is not cancelled on Firebase's side, so blindly
+        // retrying it can push the same alert to every user two or three
+        // times. Only repeat errors Firebase reports as a clean rejection.
+        shouldRetry: isRetriableFirebaseError,
+      },
+    )
+
+    logger.info('Firebase notification sent', { messageId, topic })
+    return messageId
   }
 }

--- a/packages/cms/src/helpers/notificationDelivery.ts
+++ b/packages/cms/src/helpers/notificationDelivery.ts
@@ -1,0 +1,111 @@
+import { TimeoutError } from './timeout'
+
+/**
+ * Delivery status stored on `notification.status`.
+ *
+ * The mobile app only ever reads rows with status `sent`, so anything else is
+ * invisible to users and exists purely to tell the admin what really happened.
+ */
+export const NOTIFICATION_STATUS = {
+  /** Firebase accepted the message and returned a message id. */
+  SENT: 'sent',
+  /** Firebase explicitly rejected the message — nothing was delivered. */
+  FAILED: 'failed',
+  /**
+   * We never got an answer (timeout, or the CMS died mid-send). The alert may
+   * or may not have gone out, so re-sending it risks notifying everyone twice.
+   */
+  UNKNOWN: 'unknown',
+} as const
+
+/**
+ * Firebase error codes that mean "we rejected this and delivered nothing".
+ * Only these are safe to retry: any other failure may already have reached the
+ * users, and a broadcast sent twice is worse than one we report as uncertain.
+ */
+const RETRIABLE_FIREBASE_ERROR_CODES = new Set([
+  'messaging/server-unavailable',
+  'messaging/internal-error',
+  // The connection never got established, so nothing reached Firebase.
+  'app/network-error',
+])
+
+/**
+ * Failures where Firebase never told us what it did with the message. Treated
+ * as `unknown` rather than `failed`: the alert may already be on its way, so
+ * re-sending it would notify every user twice.
+ */
+const UNKNOWN_OUTCOME_FIREBASE_ERROR_CODES = new Set([
+  'app/network-timeout',
+  'messaging/unknown-error',
+])
+
+const FIREBASE_ERROR_MESSAGES: { [code: string]: string } = {
+  'messaging/invalid-argument':
+    'Firebase rejected the notification because the title or the message is not valid.',
+  'messaging/invalid-payload':
+    'Firebase rejected the notification because the title or the message is not valid.',
+  'messaging/authentication-error':
+    'The CMS could not authenticate with Firebase. The service account credentials need to be checked.',
+  'messaging/mismatched-credential':
+    'The Firebase credentials configured for this CMS belong to a different project.',
+  'messaging/server-unavailable':
+    'Firebase is temporarily unavailable. Nothing was sent — please try again in a few minutes.',
+  'messaging/internal-error':
+    'Firebase returned an internal error. Nothing was sent — please try again in a few minutes.',
+  'messaging/quota-exceeded':
+    'The Firebase sending quota has been exceeded. Nothing was sent — please try again later.',
+  'app/invalid-credential':
+    'The Firebase credentials configured for this CMS are invalid or expired.',
+  'app/network-error':
+    'The CMS could not reach Firebase. Nothing was sent — check the server network connection and try again.',
+}
+
+function firebaseErrorCode(error: any): string | undefined {
+  return error?.code || error?.errorInfo?.code
+}
+
+/** True when the failure is a clean rejection that is safe to send again. */
+export function isRetriableFirebaseError(error: Error): boolean {
+  if (error instanceof TimeoutError) {
+    return false
+  }
+  const code = firebaseErrorCode(error)
+  return code ? RETRIABLE_FIREBASE_ERROR_CODES.has(code) : false
+}
+
+/**
+ * True when we cannot tell whether users received the notification. These are
+ * recorded as `unknown` rather than `failed` so nobody re-broadcasts blindly.
+ */
+export function isDeliveryOutcomeUnknown(error: Error): boolean {
+  if (error instanceof TimeoutError) {
+    return true
+  }
+  const code = firebaseErrorCode(error)
+  return code ? UNKNOWN_OUTCOME_FIREBASE_ERROR_CODES.has(code) : false
+}
+
+/** Turns a Firebase/transport error into something an admin can act on. */
+export function describeDeliveryError(error: any): string {
+  if (error instanceof TimeoutError) {
+    return 'Firebase did not answer in time, so the notification could not be confirmed. Check the Firebase console before sending it again — it may already have reached users.'
+  }
+
+  const code = firebaseErrorCode(error)
+  if (code && UNKNOWN_OUTCOME_FIREBASE_ERROR_CODES.has(code)) {
+    return `Firebase never confirmed what happened to this notification (${code}). Check the Firebase console before sending it again — it may already have reached users.`
+  }
+
+  if (code && FIREBASE_ERROR_MESSAGES[code]) {
+    return FIREBASE_ERROR_MESSAGES[code]
+  }
+
+  if (code) {
+    return `Firebase refused the notification (${code}). Nothing was sent.`
+  }
+
+  return error?.message
+    ? `The notification could not be sent: ${error.message}`
+    : 'The notification could not be sent.'
+}

--- a/packages/cms/src/helpers/retry.ts
+++ b/packages/cms/src/helpers/retry.ts
@@ -5,6 +5,13 @@ interface RetryOptions {
   baseDelay?: number
   maxDelay?: number
   label?: string
+  /**
+   * Decides whether a given failure is worth retrying. Returning false stops the
+   * loop and rethrows straight away. Defaults to retrying every error.
+   *
+   * Use this for operations that are not safe to repeat blindly
+   */
+  shouldRetry?: (error: Error) => boolean
 }
 
 /**
@@ -12,7 +19,13 @@ interface RetryOptions {
  * Jitter is added to prevent thundering herd.
  */
 export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
-  const { maxRetries = 3, baseDelay = 1000, maxDelay = 30000, label = 'Operation' } = options
+  const {
+    maxRetries = 3,
+    baseDelay = 1000,
+    maxDelay = 30000,
+    label = 'Operation',
+    shouldRetry = () => true,
+  } = options
 
   let lastError: Error
 
@@ -22,10 +35,15 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions =
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error))
 
-      if (attempt >= maxRetries) {
-        logger.error(`${label} failed after ${maxRetries + 1} attempts`, {
+      const attemptsUsed = attempt + 1
+      const retriesExhausted = attempt >= maxRetries
+      const retriable = shouldRetry(lastError)
+
+      if (retriesExhausted || !retriable) {
+        logger.error(`${label} failed after ${attemptsUsed} attempt(s)`, {
           message: lastError.message,
-          attempt: attempt + 1,
+          attempt: attemptsUsed,
+          retriable,
         })
         throw lastError
       }
@@ -34,7 +52,7 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions =
       const jitter = delay * (0.5 + Math.random() * 0.5)
 
       logger.warn(
-        `${label} failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${Math.round(
+        `${label} failed (attempt ${attemptsUsed}/${maxRetries + 1}), retrying in ${Math.round(
           jitter,
         )}ms`,
         {

--- a/packages/cms/src/helpers/timeout.ts
+++ b/packages/cms/src/helpers/timeout.ts
@@ -1,10 +1,28 @@
 /**
+ * Raised when a promise wrapped by {@link withTimeout} does not settle in time.
+ *
+ * The timer does not cancel the underlying work: it only stops us waiting for
+ * it. Callers therefore have to treat this as "outcome unknown" rather than
+ * "the operation did not happen".
+ */
+export class TimeoutError extends Error {
+  readonly timeoutMs: number
+
+  constructor(label: string, ms: number) {
+    super(`${label} timed out after ${ms}ms`)
+    this.name = 'TimeoutError'
+    this.timeoutMs = ms
+    Object.setPrototypeOf(this, TimeoutError.prototype)
+  }
+}
+
+/**
  * Wraps a promise with a timeout. Rejects if the promise doesn't resolve within the given time.
  */
 export function withTimeout<T>(promise: Promise<T>, ms: number, label = 'Operation'): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
-      reject(new Error(`${label} timed out after ${ms}ms`))
+      reject(new TimeoutError(label, ms))
     }, ms)
 
     promise

--- a/packages/cms/src/index.ts
+++ b/packages/cms/src/index.ts
@@ -129,6 +129,7 @@ withRetry(() => createConnection(ormconfig), {
       ),
       defaultLocale,
       cookie: 'i18n',
+      updateFiles: false,
     })
 
     app.use(i18n.init)

--- a/packages/cms/src/views/Notification.ejs
+++ b/packages/cms/src/views/Notification.ejs
@@ -1,6 +1,25 @@
 <%- include('partials/Header') %> 
 <%- include('modals/NotificationModal', {headings: [__('Title'),__('Content')]}) %>
 <%- include('modals/PermanentNotificationModal') %>
+<%
+  // The mobile app only ever reads notifications whose status is 'sent', so the
+  // status below is the real delivery outcome, not just "the CMS accepted it".
+  var statusLabels = {
+    sent: __('Sent'),
+    failed: __('Failed'),
+    unknown: __('Unknown'),
+  }
+  var statusClasses = {
+    sent: 'badge-success',
+    failed: 'badge-danger',
+    unknown: 'badge-warning',
+  }
+  var statusTitles = {
+    sent: __('Firebase confirmed this notification was accepted for delivery.'),
+    failed: __('Firebase rejected this notification. Nobody received it.'),
+    unknown: __('Delivery could not be confirmed. It may or may not have reached users - check Firebase before sending it again.'),
+  }
+%>
 <div class="homePageContainer">
   <div class="sideBar">
     <%- include('partials/SideTab') %> 
@@ -33,17 +52,25 @@
         <thead >
             <tr>
                 <th class="pointer"style="width: 15%"><%= __('Date pushed')%></th>
-                <th style="width: 40%"><%= __('Title')%></th>
-                <th style="width: 40%"><%= __('Content')%></th>
-                <th style="width: 15%"><%= __('Remove')%></th>
+                <th style="width: 30%"><%= __('Title')%></th>
+                <th style="width: 30%"><%= __('Content')%></th>
+                <th style="width: 15%"><%= __('Status')%></th>
+                <th style="width: 10%"><%= __('Remove')%></th>
             </tr>
         </thead>
         <tbody style="overflow-y: scroll" id="notifications-table-body">
           <% notifications.forEach((notification, index) => { %>
+          <% var status = notification.status || 'unknown' %>
           <tr>
             <td><%= notification.date_sent ? moment(parseInt(notification.date_sent)).format('D/M/YY') : ''%></td>
             <td><%= notification.title %></td>
             <td><%= notification.content %></td>
+            <td>
+              <span
+                class="badge <%= statusClasses[status] || 'badge-secondary' %>"
+                title="<%= statusTitles[status] || '' %>"
+              ><%= statusLabels[status] || status %></span>
+            </td>
             <td>
               <button type="button" class="btn deleteNotification" data-value="<%= notification.id %>">
                 <i class="fas fa-trash" aria-hidden="true"></i>
@@ -104,15 +131,65 @@
   <span id="permanentAlertsJSON" hidden>
     <%= JSON.stringify(permanentNotifications); %>
   </span>
+  <!--
+    Translated strings are handed to the script through data attributes: EJS
+    escapes them safely for an HTML attribute, whereas interpolating them into a
+    JS string literal would break on any quote or apostrophe.
+  -->
+  <span
+    id="notificationStrings"
+    hidden
+    data-missing-fields="<%= __('Please fill in both a title and a content before sending.') %>"
+    data-confirm="<%= __('This notification will be sent out to all users immediately, do you wish to proceed?') %>"
+    data-generic-error="<%= __('The notification could not be sent. Please check the logs and try again.') %>"
+    data-network-error="<%= __('The CMS could not be reached, so it is unclear whether the notification was sent. Reload this page to check its status before trying again.') %>"
+  ></span>
   <script>
+    var notificationStrings = $('#notificationStrings').data()
+
+    // A failed send still writes a row (the attempt is recorded before Firebase
+    // is contacted), but the modal stays open to show the reason instead of
+    // reloading. Refresh on close so the new row shows up in the table without
+    // the admin having to reload the page by hand.
+    var notificationRecordCreated = false
+
+    $('#dynamicModal').on('show.bs.modal', function () {
+      $('#notificationSendError').hide().text('')
+      $('#notificationSendPending').hide()
+      $('#btnAddConfirm').prop('disabled', false)
+      notificationRecordCreated = false
+    })
+
+    $('#dynamicModal').on('hidden.bs.modal', function () {
+      if (notificationRecordCreated) {
+        location.reload()
+      }
+    })
+
     $('#btnAddConfirm').on('click', function (e) {
         e.preventDefault();
+        var confirmButton = $(this)
+        var errorBox = $('#notificationSendError')
+        var pendingBox = $('#notificationSendPending')
         var titleInput = $('#col0TableModal');
         var contentInput = $('#col1TableModal')
-        var title = titleInput.val();
-        var content = contentInput.val();
-        var result = confirm('This notification will be sent out to all users immediately, do you wish to proceed?')
+        var title = (titleInput.val() || '').trim();
+        var content = (contentInput.val() || '').trim();
+
+        errorBox.hide().text('')
+
+        if (!title || !content) {
+          errorBox.text(notificationStrings.missingFields).show()
+          return
+        }
+
+        var result = confirm(notificationStrings.confirm)
         if (result) {
+          // Block the button while the request is in flight: a second click
+          // would broadcast the same alert to every user twice.
+          confirmButton.prop('disabled', true)
+          pendingBox.show()
+
           $.ajax({
               url: '/notification',
               method: 'POST',
@@ -122,6 +199,23 @@
               },
               success: function () {
                   location.reload()
+              },
+              error: function (xhr) {
+                  confirmButton.prop('disabled', false)
+                  pendingBox.hide()
+                  // A 400 is rejected before anything is written; every other
+                  // failure means the attempt was already recorded.
+                  if (xhr.status !== 400) {
+                    notificationRecordCreated = true
+                  }
+                  // The server explains exactly why Firebase refused it; fall
+                  // back to a generic message when it never answered at all.
+                  var message =
+                    (xhr.responseJSON && xhr.responseJSON.error) ||
+                    (xhr.status === 0
+                      ? notificationStrings.networkError
+                      : notificationStrings.genericError)
+                  errorBox.text(message).show()
               }
           })
         }

--- a/packages/cms/src/views/modals/NotificationModal.ejs
+++ b/packages/cms/src/views/modals/NotificationModal.ejs
@@ -33,6 +33,15 @@
             </td>
           </tbody>
         </table>
+        <div
+          id="notificationSendError"
+          class="alert alert-danger"
+          role="alert"
+          style="display: none"
+        ></div>
+        <div id="notificationSendPending" class="text-muted" style="display: none">
+          <%= __('Sending the notification, please wait...')%>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal"><%= __('Close')%></button>


### PR DESCRIPTION
## 📌 Summary

Sending a push notification from the CMS reported success no matter what actually happened. The row was written with `status = 'sent'` unconditionally, and the browser handler had no error callback at all, so a rejected send left the admin looking at an unchanged modal with no indication of whether users had been notified.

This PR makes the CMS record and display the real delivery outcome, and gives the admin an actionable reason whenever a broadcast does not go through.

## 🔗 Ticket / Issue

* N/A

## ✅ Changes

* Fix: Real delivery status for push notifications (`sent` / `failed` / `unknown`), surfaced in the admin UI instead of an unconditional "sent"
* Refactor: `withRetry` gained an optional `shouldRetry` predicate; `withTimeout` now rejects with a typed `TimeoutError`
* Other: `i18n updateFiles: false`, stops the CMS writing into the `common` git submodule at runtime

## 🧪 Testing

1. **Happy path:** `Notifications` → `Add Notification` → fill title/content → `Confirm`.
2. **Real failure:** add `extra_hosts: ["fcm.googleapis.com:127.0.0.1"]` to the `cms` service in `docker-compose.override.yml`, then `docker compose up -d --force-recreate cms`. Send another notification.
3. **Unknown outcome:** keep the hosts entry and make port 443 accept but never answer, `docker compose exec -d cms node -e "require('net').createServer(()=>{}).listen(443)"`. Send again.
4. **Double-click guard:** with step 3 active, click `Confirm` and try clicking again.


* ✅ Expected result:

| Step | Result |
|---|---|
| 1 | Green **`Sent`** badge. Logs show a real `messageId` (`projects/…/messages/…`). |
| 2 | Red error box in the modal with the reason, `POST /notification` → **502**, red **`Failed`** badge after reload. |
| 3 | Hangs ~15s, then *"Firebase did not answer in time… it may already have reached users"*, yellow **`Unknown`** badge. Send attempted **exactly once**. |
| 4 | Button stays disabled for the whole request. |
| 5 | Never returns a `failed` or `unknown` row. |

Also verified: empty title/content is rejected client- and server-side with no DB write; closing the modal after a failed send refreshes the table automatically.

* ❌ Bugs to watch out for:

* **Existing rows all display `Sent`.** The old code wrote that value unconditionally, so historical outcomes cannot be recovered. Not a regression, worth knowing before reading the table.
* **`Sent` means Firebase accepted the message, not that every device received it.** FCM does not report per-device delivery for topic sends. This is the ceiling of certainty on this channel.
* **11 new UI strings render in English** in every locale until they are added to the content team's translation spreadsheet. Nothing breaks, i18n falls back to  the English key text.
* Firebase failure reasons come from the server as plain English and never pass  through i18n (see Notes below).

## 📸 Screenshots (if applicable)



### Before

<img width="2554" height="955" alt="Screenshot from 2026-08-23 22-21-05" src="https://github.com/user-attachments/assets/672b3f57-73b4-44f4-acd3-389b700a68b3" />

### After
<img width="1518" height="775" alt="Screenshot from 2026-08-23 22-13-37" src="https://github.com/user-attachments/assets/0b931b36-5fc4-4e50-92a0-fdb7336d167c" />
<img width="2554" height="955" alt="Screenshot from 2026-08-23 22-17-15" src="https://github.com/user-attachments/assets/97e63411-60d8-4461-9ea7-d189716055e0" />
<img width="2554" height="955" alt="Screenshot from 2026-08-23 22-26-46" src="https://github.com/user-attachments/assets/3ec0595f-7f15-47bd-8601-a85c68667756" />
<img width="2559" height="559" alt="Screenshot from 2026-08-23 22-27-12" src="https://github.com/user-attachments/assets/fd96060f-bbde-4498-ba47-cf3b9897c36e" />

## 📖 Notes for Reviewers


**Why the row is written *before* Firebase is contacted**
If the CMS crashed mid-send, a delivered alert would leave no trace, and an admin seeing no record would simply send it again, notifying every user twice. The row starts as `unknown` and is only promoted to `sent` once Firebase returns a message id.

**Why timeouts are `unknown` and not `failed`**
`withTimeout` does not cancel the underlying FCM call, so a timed-out broadcast may well have been delivered. Reporting it as a clean failure would push the admin toward a duplicate send. The same reasoning applies to `app/network-timeout` and `messaging/unknown-error`.

**Retry policy change, please review this closely**
`withRetry` previously repeated *every* failure, timeouts included, which could deliver one alert to every user of a language two or three times. Retries are now limited to errors Firebase reports as a definite non-delivery (`messaging/server-unavailable`, `messaging/internal-error`, `app/network-error`). The new `shouldRetry` option defaults to the previous always-retry behaviour, so the only other caller (the DB connection in `index.ts`) is unaffected.

**No migration required**
The existing `status` varchar carries `failed` and `unknown` without any schema change. `/mobile/notification/:lang` still filters on `status = 'sent'`, so the new values are admin-only and never reach the app.

**The one change outside this feature**
`i18n updateFiles: false` in `index.ts` (4 lines). By default i18n writes missing keys back into the locale files, which live in the `common` git submodule, owned by the content team's spreadsheet import. This PR adds 11 new keys, so without it the CMS would start writing into that submodule at runtime.

**Known limitation, candidate for a follow-up**
Firebase error reasons are hardcoded English strings in `helpers/notificationDelivery.ts` and are sent straight to the browser in the 502 body, bypassing i18n entirely. Making them translatable means returning keys instead
of text *and* getting those keys translated, both steps, or the admin sees raw identifiers. Suggested for next fix.

### Checklist

* [x] Code follows style guidelines
* [x] Self-review completed
* [ ] Tests added/updated
* [ ] Documentation updated
* [x] No sensitive info (keys, secrets, etc.) committed