### PR TITLE
fix(cms): harden session cookie flags and enforce server-side expiry

### DIFF
--- a/packages/cms/src/access/session.ts
+++ b/packages/cms/src/access/session.ts
@@ -1,0 +1,46 @@
+import { NextFunction, Request, Response } from 'express'
+import { env } from '../env'
+
+/** Absolute session lifetime, after which the user has to log in again. */
+export const SESSION_MAX_AGE_MS = 8 * 60 * 60 * 1000 // 8 hours
+
+// `cookie-session` reads these flags from the top level, not from a nested
+// `cookie` object.
+export const sessionOptions = {
+  name: 'session',
+  secret: env.app.secret,
+  signed: true,
+  overwrite: true,
+  httpOnly: true,
+  sameSite: 'strict' as const,
+  secure: env.isProduction, // needs `trust proxy` to be set behind the ingress
+  maxAge: SESSION_MAX_AGE_MS,
+}
+
+/**
+ * Expires sessions server-side.
+ *
+ * The session lives entirely in the signed cookie, so `maxAge` only asks the
+ * browser to drop it. Stamping the expiry into the payload and checking it here
+ * is what bounds the lifetime of a cookie that gets copied elsewhere.
+ */
+export function enforceSessionExpiry(request: Request, response: Response, next: NextFunction) {
+  const session = request.session as any
+
+  // Anonymous visitors get a session too (connect-flash writes one on the login
+  // page); there is nothing to expire until someone logs in.
+  if (!session || !session.passport || !session.passport.user) {
+    return next()
+  }
+
+  if (typeof session.expiresAt !== 'number') {
+    session.expiresAt = Date.now() + SESSION_MAX_AGE_MS
+    return next()
+  }
+
+  if (Date.now() >= session.expiresAt) {
+    request.session = null
+  }
+
+  return next()
+}

--- a/packages/cms/src/controller/AccessController.ts
+++ b/packages/cms/src/controller/AccessController.ts
@@ -17,6 +17,7 @@ export class AccessController {
       }
       return
     })
+    request.session = null
     response.redirect('/login')
   }
 }

--- a/packages/cms/src/index.ts
+++ b/packages/cms/src/index.ts
@@ -11,6 +11,7 @@ import { Strategy } from 'passport-local'
 import cookieParser from 'cookie-parser'
 import session from 'cookie-session'
 import { Authentication } from './access/authentication'
+import { enforceSessionExpiry, sessionOptions } from './access/session'
 import * as admin from 'firebase-admin'
 import { env } from './env'
 import ormconfig from '../ormconfig'
@@ -24,6 +25,7 @@ import helmet from 'helmet'
 createConnection(ormconfig)
   .then(() => {
     const app = express()
+    app.set('trust proxy', 1)
     app.set('view engine', 'ejs')
     app.set('views', __dirname + '/views')
 
@@ -84,17 +86,8 @@ createConnection(ormconfig)
     app.use(i18n.init)
     // ======================= Passport Configuration =============================
     app.use(cookieParser())
-    app.use(
-      session({
-        secret: env.app.secret,
-        resave: false,
-        saveUninitialized: false,
-        cookie: {
-          sameSite: 'strict',
-          secure: process.env.NODE_ENV === 'production',
-        },
-      }),
-    )
+    app.use(session(sessionOptions))
+    app.use(enforceSessionExpiry)
     app.use(passport.initialize())
     app.use(passport.session())
     app.use(flash())
@@ -181,5 +174,9 @@ createConnection(ormconfig)
 
     app.listen(5000)
     console.log('Server started on port 5000')
+    console.log(
+      `Session cookie: secure=${sessionOptions.secure} sameSite=${sessionOptions.sameSite} ` +
+        `httpOnly=${sessionOptions.httpOnly} maxAge=${sessionOptions.maxAge}ms`,
+    )
   })
   .catch((error) => console.log(error))


### PR DESCRIPTION
## 📌 Summary

The CMS session options were written in the `express-session` shape, with the cookie flags nested under a `cookie` key. This app uses `cookie-session`, which reads those flags from the top level and ignores unknown keys, so `sameSite: 'strict'` and `secure` never applied. The production session cookie was going out as `session=<payload>; path=/; httponly`: no CSRF protection, no HTTPS requirement, and no expiry at all.

There are no `@types/cookie-session` installed and `noImplicitAny` is off, so the options object was typed `any` and TypeScript never flagged the mismatch.

This moves the flags to where `cookie-session` reads them, adds an 8h session lifetime enforced server-side, and trusts the ingress proxy so `secure` can actually take effect.

## 🔗 Ticket / Issue

* N/A

## ✅ Changes

* [ ] Feature: ...
* [x] Fix: 
 - Cookie flags moved to the top level of the `cookie-session` options, where they are actually read (`httpOnly`, `sameSite=strict`, `secure`)
-  `app.set('trust proxy', 1)` so Express sees `X-Forwarded-Proto` from the ingress, without it `cookie-session` silently drops a `secure` cookie
* [x] Refactor: session config extracted to `packages/cms/src/access/session.ts`
* [ ] Docs: ...
* [ ] Tests: ...
* [x] Other: startup log line printing the effective cookie flags, so each environment can be verified from its logs

## 🧪 Testing

Verified locally

**Steps to reproduce:**

1. Log in at `http://localhost:5000/login`, then open DevTools → Application → Cookies → the `session` row.
   - Before: `SameSite` blank, `Expires` = "Session".
   - After: `SameSite` = `Strict`, `Expires` = a date ~8h out.
2. From a different site, click a plain link into the CMS (`printf '<a href="http://localhost:5000/encyclopedia">go</a>' > x.html`, served on `http://127.0.0.1:8081`).
   - Before: loads the page, still logged in.
   - After: redirected to the login page, Strict withholds the cookie.
3. Temporarily set `SESSION_MAX_AGE_MS = 60 * 1000`, restart, log in, wait 65s, click any page.
   - Before: keeps browsing indefinitely.
   - After: redirected to login. Pasting the old cookie value back in via the DevTools cookie editor does not restore the session, the expiry is inside the signed payload. (Constant restored to 8h before committing.)
4. On a staging deploy: startup log shows `secure=true`, and `curl -sI https://<cms-host>/login | grep -i set-cookie` shows `secure; samesite=strict; httponly` plus an `expires`.

* ✅ Expected result: the session cookie carries `httponly`, `samesite=strict`, an 8h `expires`, and `secure` wherever the CMS runs over HTTPS; sessions stop working 8h after login even if the cookie is replayed by another client.
* ❌ Bugs to watch out for: 
  - **Login loop in production.** `secure` is now genuinely enforced. If TLS  terminates somewhere that does not forward `X-Forwarded-Proto: https`, `cookie-session` swallows the resulting error and never sets the cookie, login fails with nothing in the logs. `trust proxy` is set to `1`, i.e. one hop; anything in front of the ingress (Cloudflare, an extra LB) needs that count raised.
  - **Deep links land on the login page.** With `SameSite=Strict`, a CMS link opened from Slack or email shows the login screen even for a live session. One extra click. `lax` still blocks CSRF if that trade is not worth it.
  - **Browser restart now keeps you logged in** (up to the 8h ceiling), because the cookie is no longer session-scoped. Net tightening, not a loosening, previously a session survived indefinitely as long as the window stayed open.
  - Deploying does not log existing users out; their cookies get stamped on their next request and expire 8h later.

## 📸 Screenshots (if applicable)

<!-- Add before/after screenshots or recordings -->

### Before
<img width="1080" height="119" alt="Screenshot from 2026-08-24 10-53-38" src="https://github.com/user-attachments/assets/b2049e7b-447c-4f1c-818a-1594ae4fc068" />

----- -----
<img width="2560" height="252" alt="Screenshot from 2026-08-24 11-03-08" src="https://github.com/user-attachments/assets/beccbdd3-5a1b-461c-875e-d4c8b1c5ab93" />

<img width="2560" height="967" alt="Screenshot from 2026-08-24 11-05-10" src="https://github.com/user-attachments/assets/ae947f07-ffb0-4c70-b466-c4b1616a56a2" />

<!-- Screenshot or description -->

### After

<!-- Screenshot or description -->
<img width="1080" height="119" alt="Screenshot from 2026-08-24 10-55-32" src="https://github.com/user-attachments/assets/c9df6aac-aff6-4a0f-abd2-f000c08175a0" />

----- -----
<img width="2560" height="252" alt="Screenshot from 2026-08-24 11-03-08" src="https://github.com/user-attachments/assets/9c7b1a95-37ff-433d-8608-1c36274a0139" />
<img width="2560" height="967" alt="Screenshot from 2026-08-24 11-03-16" src="https://github.com/user-attachments/assets/a61a854e-f203-4b29-b03b-c47769779a39" />

## 📖 Notes for Reviewers


* The core of the review is `packages/cms/src/access/session.ts`. Flags belong at the top level of the options object, re-nesting them under a `cookie` key  would silently disable them again, with no type error.
* `maxAge` alone would not have closed the ticket. `cookie-session` is stateless: the session *is* the signed cookie, so `maxAge` is only an instruction to the browser. A cookie copied and replayed by any other client (curl ignores `Expires`) stayed valid forever. The `expiresAt` stamp is what bounds it.
* `enforceSessionExpiry` runs before `passport.session()`, so a cleared session deserializes no user and falls through to `Authentication.isLoggedIn`.
* The expiry is absolute, not sliding, and only starts once a `passport.user` exists, anonymous visitors get a session too (`connect-flash` writes one on the login page) and starting the clock there would cut short the session of anyone who left the login page open before signing in.
* `request.session = null` on logout is a tidy-up, not a revocation: passport already removes the user from the payload. A stateless session cannot be revoked server-side, so a cookie copied before logout stays valid until its stamped expiry. Adding real revocation would mean a session store or a token version on the user row, out of scope here.
* Deployment env audit: `.k8s/cms.yaml` and the Dockerfile production stage both set `NODE_ENV=production` ✅. One gap, `docker-compose.yml` passes `env_file: packages/cms/.env`, and Compose's `env_file` overrides the image's `ENV`, so building the production target through Compose with a `.env` copied from `.env.dist` would silently disable `secure`. The startup log line catches this in any environment.

---

### Checklist

* [x] Code follows style guidelines
* [x] Self-review completed
* [ ] Tests added/updated
* [ ] Documentation updated
* [x] No sensitive info (keys, secrets, etc.) committed