### PR TITLE
fix: correct onboarding cycle length default and floor

### DIFF
--- a/app/src/screens/AuthScreen/components/Journey/JourneyContext.tsx
+++ b/app/src/screens/AuthScreen/components/Journey/JourneyContext.tsx
@@ -49,7 +49,7 @@ const initialState: JourneyState = {
   isActive: false,
   startDate: twoWeeksAgo,
   periodLength: '5',
-  cycleLength: '3',
+  cycleLength: '4',
   hasSkipped: false,
 }
 

--- a/app/src/screens/AuthScreen/components/Journey/components/JourneyReview.tsx
+++ b/app/src/screens/AuthScreen/components/Journey/components/JourneyReview.tsx
@@ -30,8 +30,7 @@ export const JourneyReview = () => {
     }
 
     const periodLength = parseInt(state.periodLength)
-    const cycleLengthDays = parseInt(state.cycleLength) * 7
-    const cycleLength = cycleLengthDays + periodLength
+    const cycleLength = Math.max(parseInt(state.cycleLength) * 7, periodLength + 2)
 
     const answers = {
       isActive: state.isActive,


### PR DESCRIPTION
## 🔗 Ticket / Issue
Ports #258 onto `release/8.5.0`. Original PR by @Zenrahul08, already merged to `master` (f494497).

## ✅ Changes
* [x] Fix: cycle length no longer adds period duration; onboarding default bumped 3 → 4 weeks

Same change as #258, see that PR for the full write-up and @Cedric-RA's explanation of why the default bump has to ship alongside the separation fix.

This is **not** a revert. The code is already in `master`; this PR only gets it onto the release branch so it ships with 8.5.0. When `release/8.5.0` merges back to `master`, these lines will show no diff, that's expected, not a lost change.

## 🧪 Testing
Covered in #258. Re-verified on this branch:
1. Fresh onboarding, period duration 5 days, cycle length 4 weeks
2. ✅ Cycle length stores as 28, not 33
3. ✅ Next predicted period lands 28 days out, not 33

## 📖 Notes for Reviewers
Cherry-picked from #258 (079a41e + 783d02b). The submodule pointer commit (42fbc37) was intentionally left out,  it's specific to `master`'s state.

### Checklist
* [x] Self-review completed
* [x] No sensitive info committed